### PR TITLE
69 store date of creation for storage space and product

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
     implementation("org.jetbrains.exposed:exposed-dao:$exposed_version")
     implementation("org.jetbrains.exposed:exposed-json:$exposed_version")
+    implementation("org.jetbrains.exposed:exposed-java-time:$exposed_version")
     implementation("org.postgresql:postgresql:$postgresql_version")
     implementation("io.ktor:ktor-server-cors-jvm")
     implementation("io.ktor:ktor-server-netty-jvm")

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -13,11 +13,13 @@ class PostgresProductRepository : ProductRepository {
         spaceId: String
     ): Product = transaction {
         val space = SpaceEntity.findById(UUID.fromString(spaceId)) ?: return@transaction throw IllegalArgumentException("Space not found")
+        val createTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         ProductEntity.new {
             this.name = name
             this.description = description
             this.space = space
-            this.creationTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
+            this.creationTime = createTime
+            this.updatedAt = createTime
         }.toProduct()
     }
 
@@ -39,6 +41,7 @@ class PostgresProductRepository : ProductRepository {
             name?.let { product.name = it }
             description?.let { product.description = it }
             spaceId?.let { product.space = SpaceEntity.findById(UUID.fromString(it)) ?: throw IllegalArgumentException("Space not found") }
+            product.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }?.toProduct()
     }
 
@@ -46,6 +49,7 @@ class PostgresProductRepository : ProductRepository {
         val targetSpace = SpaceEntity.findById(UUID.fromString(spaceId)) ?: throw IllegalArgumentException("target Space not found")
         ProductEntity.findByIdAndUpdate(UUID.fromString(id)) { product ->
             product.space = targetSpace
+            product.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }?.toProduct()
 
     }

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -1,6 +1,7 @@
 package io.github.lagersystembackend.product
 import io.github.lagersystembackend.space.SpaceEntity
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 import java.util.UUID
 
 class PostgresProductRepository : ProductRepository {
@@ -15,6 +16,7 @@ class PostgresProductRepository : ProductRepository {
             this.name = name
             this.description = description
             this.space = space
+            this.creationTime = LocalDateTime.now()
         }.toProduct()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -2,6 +2,7 @@ package io.github.lagersystembackend.product
 import io.github.lagersystembackend.space.SpaceEntity
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class PostgresProductRepository : ProductRepository {
@@ -16,7 +17,7 @@ class PostgresProductRepository : ProductRepository {
             this.name = name
             this.description = description
             this.space = space
-            this.creationTime = LocalDateTime.now()
+            this.creationTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }.toProduct()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -18,8 +18,6 @@ class PostgresProductRepository : ProductRepository {
             this.name = name
             this.description = description
             this.space = space
-            this.creationTime = createTime
-            this.updatedAt = createTime
         }.toProduct()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -11,6 +11,9 @@ import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.javatime.datetime
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 
@@ -19,7 +22,8 @@ data class Product(
     val name: String,
     val description: String,
     val attributes: Map<String, Attribute>,
-    val spaceId: String
+    val spaceId: String,
+    val creationTime: LocalDateTime
 )
 
 @Serializable
@@ -28,7 +32,8 @@ data class NetworkProduct(
     val name: String,
     val description: String,
     val attributes: Map<String, Attribute>,
-    val spaceId: String
+    val spaceId: String,
+    val creationTime: String
 )
 
 @Serializable
@@ -43,6 +48,7 @@ object Products: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
     val spaceId = reference("spaceId", Spaces)
+    val creationTime = datetime("creationTime")
 }
 
 class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
@@ -52,6 +58,7 @@ class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var description by Products.description
     val attributes by ProductAttributeEntity referrersOn ProductAttributes.productId
     var space by SpaceEntity referencedOn Products.spaceId
+    var creationTime by Products.creationTime
 }
 
 fun ProductEntity.toProduct() = Product(
@@ -59,7 +66,8 @@ fun ProductEntity.toProduct() = Product(
     name,
     description,
     attributes.associate { it.key to it.toAttribute() },
-    space.id.value.toString()
+    space.id.value.toString(),
+    creationTime
 )
 
 fun Product.toNetworkProduct() = NetworkProduct(
@@ -67,5 +75,6 @@ fun Product.toNetworkProduct() = NetworkProduct(
     name,
     description,
     attributes,
-    spaceId
+    spaceId,
+    creationTime.format(DateTimeFormatter.ISO_DATE_TIME)
 )

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.javatime.datetime
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -48,7 +49,7 @@ object Products: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
     val spaceId = reference("spaceId", Spaces)
-    val creationTime = datetime("creationTime")
+    val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
 }
 
 class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -24,7 +24,8 @@ data class Product(
     val description: String,
     val attributes: Map<String, Attribute>,
     val spaceId: String,
-    val creationTime: LocalDateTime
+    val creationTime: LocalDateTime,
+    val updatedAt: LocalDateTime
 )
 
 @Serializable
@@ -34,7 +35,8 @@ data class NetworkProduct(
     val description: String,
     val attributes: Map<String, Attribute>,
     val spaceId: String,
-    val creationTime: String
+    val creationTime: String,
+    val updatedAt: String
 )
 
 @Serializable
@@ -50,6 +52,7 @@ object Products: UUIDTable() {
     val description = text("description")
     val spaceId = reference("spaceId", Spaces)
     val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updatedAt").defaultExpression(CurrentDateTime)
 }
 
 class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
@@ -60,6 +63,7 @@ class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     val attributes by ProductAttributeEntity referrersOn ProductAttributes.productId
     var space by SpaceEntity referencedOn Products.spaceId
     var creationTime by Products.creationTime
+    var updatedAt by Products.updatedAt
 }
 
 fun ProductEntity.toProduct() = Product(
@@ -68,7 +72,8 @@ fun ProductEntity.toProduct() = Product(
     description,
     attributes.associate { it.key to it.toAttribute() },
     space.id.value.toString(),
-    creationTime
+    creationTime,
+    updatedAt
 )
 
 fun Product.toNetworkProduct() = NetworkProduct(
@@ -77,5 +82,6 @@ fun Product.toNetworkProduct() = NetworkProduct(
     description,
     attributes,
     spaceId,
-    creationTime.format(DateTimeFormatter.ISO_DATE_TIME)
+    creationTime.format(DateTimeFormatter.ISO_DATE_TIME),
+    updatedAt.format(DateTimeFormatter.ISO_DATE_TIME),
 )

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -24,8 +24,8 @@ data class Product(
     val description: String,
     val attributes: Map<String, Attribute>,
     val spaceId: String,
-    val creationTime: LocalDateTime,
-    val updatedAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
 )
 
 @Serializable
@@ -35,8 +35,8 @@ data class NetworkProduct(
     val description: String,
     val attributes: Map<String, Attribute>,
     val spaceId: String,
-    val creationTime: String,
-    val updatedAt: String
+    val createdAt: String,
+    val updatedAt: String?
 )
 
 @Serializable
@@ -51,8 +51,8 @@ object Products: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
     val spaceId = reference("spaceId", Spaces)
-    val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
-    val updatedAt = datetime("updatedAt").defaultExpression(CurrentDateTime)
+    val createdAt = datetime("createdAt").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updatedAt").nullable()
 }
 
 class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
@@ -62,7 +62,7 @@ class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var description by Products.description
     val attributes by ProductAttributeEntity referrersOn ProductAttributes.productId
     var space by SpaceEntity referencedOn Products.spaceId
-    var creationTime by Products.creationTime
+    var createdAt by Products.createdAt
     var updatedAt by Products.updatedAt
 }
 
@@ -72,7 +72,7 @@ fun ProductEntity.toProduct() = Product(
     description,
     attributes.associate { it.key to it.toAttribute() },
     space.id.value.toString(),
-    creationTime,
+    createdAt,
     updatedAt
 )
 
@@ -82,6 +82,6 @@ fun Product.toNetworkProduct() = NetworkProduct(
     description,
     attributes,
     spaceId,
-    creationTime.format(DateTimeFormatter.ISO_DATE_TIME),
-    updatedAt.format(DateTimeFormatter.ISO_DATE_TIME),
+    createdAt.format(DateTimeFormatter.ISO_DATE_TIME),
+    updatedAt?.format(DateTimeFormatter.ISO_DATE_TIME),
 )

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -14,12 +14,14 @@ class PostgresSpaceRepository : SpaceRepository {
         storageId: String
     ): Space = transaction {
         val storage = StorageEntity.findById(UUID.fromString(storageId)) ?: throw IllegalArgumentException("Storage not found")
+        val createTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         SpaceEntity.new {
             this.name = name
             this.size = size
             this.description = description
             this.storage = storage
-            this.creationTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
+            this.creationTime = createTime
+            this.updatedAt = createTime
         }.toSpace()
     }
 
@@ -41,6 +43,7 @@ class PostgresSpaceRepository : SpaceRepository {
             name?.let { space.name = it }
             size?.let { space.size = it }
             description?.let { space.description = it }
+            space.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }?.toSpace()
     }
 
@@ -63,7 +66,7 @@ class PostgresSpaceRepository : SpaceRepository {
             ?: throw IllegalArgumentException("Storage with ID $targetStorageId not found")
 
         space.storage = targetStorage
-
+        space.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         space.toSpace()
     }
 }

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -20,8 +20,6 @@ class PostgresSpaceRepository : SpaceRepository {
             this.size = size
             this.description = description
             this.storage = storage
-            this.creationTime = createTime
-            this.updatedAt = createTime
         }.toSpace()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -2,6 +2,7 @@ package io.github.lagersystembackend.space
 
 import io.github.lagersystembackend.storage.StorageEntity
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 import java.util.UUID
 
 class PostgresSpaceRepository : SpaceRepository {
@@ -17,6 +18,7 @@ class PostgresSpaceRepository : SpaceRepository {
             this.size = size
             this.description = description
             this.storage = storage
+            this.creationTime = LocalDateTime.now()
         }.toSpace()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -3,6 +3,7 @@ package io.github.lagersystembackend.space
 import io.github.lagersystembackend.storage.StorageEntity
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class PostgresSpaceRepository : SpaceRepository {
@@ -18,7 +19,7 @@ class PostgresSpaceRepository : SpaceRepository {
             this.size = size
             this.description = description
             this.storage = storage
-            this.creationTime = LocalDateTime.now()
+            this.creationTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }.toSpace()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -27,7 +27,8 @@ data class Space(
     val description: String,
     val products: List<Product>,
     val storageId: String,
-    val creationTime: LocalDateTime
+    val creationTime: LocalDateTime,
+    val updatedAt: LocalDateTime
 )
 
 @Serializable
@@ -38,7 +39,8 @@ data class NetworkSpace(
     val description: String,
     val products: List<NetworkProduct>?,
     val storageId: String,
-    val creationTime: String
+    val creationTime: String,
+    val updatedAt: String
 )
 
 @Serializable
@@ -60,6 +62,7 @@ object Spaces: UUIDTable() {
     val description = text("description")
     val storageId = reference("storageId", Storages)
     val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updatedAt").defaultExpression(CurrentDateTime)
 }
 
 class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
@@ -71,6 +74,7 @@ class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     val products by ProductEntity referrersOn Products.spaceId
     var storage by StorageEntity referencedOn Spaces.storageId
     var creationTime by Spaces.creationTime
+    var updatedAt by Spaces.updatedAt
 
     override fun delete() {
         products.forEach { it.delete() }
@@ -85,7 +89,8 @@ fun SpaceEntity.toSpace() = Space(
     description,
     products.map { it.toProduct() },
     storage.id.value.toString(),
-    creationTime
+    creationTime,
+    updatedAt
 )
 
 fun Space.toNetworkSpace() = NetworkSpace(
@@ -95,5 +100,6 @@ fun Space.toNetworkSpace() = NetworkSpace(
     description,
     products.map { it.toNetworkProduct() },
     storageId,
-    creationTime.format(DateTimeFormatter.ISO_DATE_TIME)
+    creationTime.format(DateTimeFormatter.ISO_DATE_TIME),
+    updatedAt.format(DateTimeFormatter.ISO_DATE_TIME)
 )

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -13,6 +13,7 @@ import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.javatime.datetime
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -58,7 +59,7 @@ object Spaces: UUIDTable() {
     val size = float("size").nullable()
     val description = text("description")
     val storageId = reference("storageId", Storages)
-    val creationTime = datetime("creationTime")
+    val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
 }
 
 class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -27,8 +27,8 @@ data class Space(
     val description: String,
     val products: List<Product>,
     val storageId: String,
-    val creationTime: LocalDateTime,
-    val updatedAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
 )
 
 @Serializable
@@ -39,8 +39,8 @@ data class NetworkSpace(
     val description: String,
     val products: List<NetworkProduct>?,
     val storageId: String,
-    val creationTime: String,
-    val updatedAt: String
+    val createdAt: String,
+    val updatedAt: String?
 )
 
 @Serializable
@@ -61,8 +61,8 @@ object Spaces: UUIDTable() {
     val size = float("size").nullable()
     val description = text("description")
     val storageId = reference("storageId", Storages)
-    val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
-    val updatedAt = datetime("updatedAt").defaultExpression(CurrentDateTime)
+    val createdAt = datetime("createdAt").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updatedAt").nullable()
 }
 
 class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
@@ -73,7 +73,7 @@ class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var description by Spaces.description
     val products by ProductEntity referrersOn Products.spaceId
     var storage by StorageEntity referencedOn Spaces.storageId
-    var creationTime by Spaces.creationTime
+    var createdAt by Spaces.createdAt
     var updatedAt by Spaces.updatedAt
 
     override fun delete() {
@@ -89,7 +89,7 @@ fun SpaceEntity.toSpace() = Space(
     description,
     products.map { it.toProduct() },
     storage.id.value.toString(),
-    creationTime,
+    createdAt,
     updatedAt
 )
 
@@ -100,6 +100,6 @@ fun Space.toNetworkSpace() = NetworkSpace(
     description,
     products.map { it.toNetworkProduct() },
     storageId,
-    creationTime.format(DateTimeFormatter.ISO_DATE_TIME),
-    updatedAt.format(DateTimeFormatter.ISO_DATE_TIME)
+    createdAt.format(DateTimeFormatter.ISO_DATE_TIME),
+    updatedAt?.format(DateTimeFormatter.ISO_DATE_TIME)
 )

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -13,6 +13,9 @@ import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.javatime.datetime
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 
@@ -22,7 +25,8 @@ data class Space(
     val size: Float?,
     val description: String,
     val products: List<Product>,
-    val storageId: String
+    val storageId: String,
+    val creationTime: LocalDateTime
 )
 
 @Serializable
@@ -32,7 +36,8 @@ data class NetworkSpace(
     val size: Float?,
     val description: String,
     val products: List<NetworkProduct>?,
-    val storageId: String
+    val storageId: String,
+    val creationTime: String
 )
 
 @Serializable
@@ -53,6 +58,7 @@ object Spaces: UUIDTable() {
     val size = float("size").nullable()
     val description = text("description")
     val storageId = reference("storageId", Storages)
+    val creationTime = datetime("creationTime")
 }
 
 class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
@@ -63,6 +69,7 @@ class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     var description by Spaces.description
     val products by ProductEntity referrersOn Products.spaceId
     var storage by StorageEntity referencedOn Spaces.storageId
+    var creationTime by Spaces.creationTime
 
     override fun delete() {
         products.forEach { it.delete() }
@@ -76,7 +83,8 @@ fun SpaceEntity.toSpace() = Space(
     size,
     description,
     products.map { it.toProduct() },
-    storage.id.value.toString()
+    storage.id.value.toString(),
+    creationTime
 )
 
 fun Space.toNetworkSpace() = NetworkSpace(
@@ -85,5 +93,6 @@ fun Space.toNetworkSpace() = NetworkSpace(
     size,
     description,
     products.map { it.toNetworkProduct() },
-    storageId
+    storageId,
+    creationTime.format(DateTimeFormatter.ISO_DATE_TIME)
 )

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -2,6 +2,7 @@ package io.github.lagersystembackend.storage
 
 import org.jetbrains.exposed.sql.SizedCollection
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 
 import java.util.UUID
 
@@ -15,6 +16,7 @@ class PostgresStorageRepository: StorageRepository {
         val newStorage = StorageEntity.new {
             this.name = name
             this.description = description
+            this.creationTime = LocalDateTime.now()
         }
         parent?.run { subStorages = SizedCollection(subStorages + newStorage) }
         newStorage.parent = parent

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -18,8 +18,6 @@ class PostgresStorageRepository: StorageRepository {
         val newStorage = StorageEntity.new {
             this.name = name
             this.description = description
-            this.creationTime = createTime
-            this.updatedAt = createTime
         }
         parent?.run { subStorages = SizedCollection(subStorages + newStorage) }
         newStorage.parent = parent

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -14,10 +14,12 @@ class PostgresStorageRepository: StorageRepository {
         parentId: String?,
     ): Storage = transaction {
         val parent = parentId?.let { StorageEntity.findById(UUID.fromString(it)) }
+        val createTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         val newStorage = StorageEntity.new {
             this.name = name
             this.description = description
-            this.creationTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
+            this.creationTime = createTime
+            this.updatedAt = createTime
         }
         parent?.run { subStorages = SizedCollection(subStorages + newStorage) }
         newStorage.parent = parent
@@ -41,6 +43,7 @@ class PostgresStorageRepository: StorageRepository {
         StorageEntity.findByIdAndUpdate(UUID.fromString(id)) { storage ->
             name?.let { storage.name = it }
             description?.let { storage.description = it }
+            storage.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }?.toStorage()
     }
 
@@ -76,6 +79,7 @@ class PostgresStorageRepository: StorageRepository {
         }
 
         storage.parent = newParent
+        storage.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         storage.toStorage()
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -3,6 +3,7 @@ package io.github.lagersystembackend.storage
 import org.jetbrains.exposed.sql.SizedCollection
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 import java.util.UUID
 
@@ -16,7 +17,7 @@ class PostgresStorageRepository: StorageRepository {
         val newStorage = StorageEntity.new {
             this.name = name
             this.description = description
-            this.creationTime = LocalDateTime.now()
+            this.creationTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }
         parent?.run { subStorages = SizedCollection(subStorages + newStorage) }
         newStorage.parent = parent

--- a/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
@@ -25,7 +25,8 @@ data class Storage(
     val spaces: List<Space>,
     val parentId: String?,
     val subStorages: List<Storage>,
-    val creationTime: LocalDateTime
+    val creationTime: LocalDateTime,
+    val updatedAt: LocalDateTime,
 )
 
 @Serializable
@@ -35,7 +36,8 @@ data class NetworkStorage(
     val description: String,
     val spaces: List<NetworkSpace>,
     val subStorages: List<NetworkStorage>,
-    val creationTime: String
+    val creationTime: String,
+    val updatedAt: String,
 )
 
 @Serializable
@@ -54,6 +56,7 @@ object Storages: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
     val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updatedAt").defaultExpression(CurrentDateTime)
 }
 
 object StorageToStorages: Table() {
@@ -83,6 +86,7 @@ class StorageEntity(id: EntityID<UUID>) : UUIDEntity(id) {
             }
         }
     var creationTime by Storages.creationTime
+    var updatedAt by Storages.updatedAt
 
     override fun delete() {
         spaces.forEach { it.delete() }
@@ -100,7 +104,8 @@ fun StorageEntity.toStorage(): Storage {
         spaces = spaces.map { it.toSpace() },
         parentId = parent?.id?.value?.toString(),
         subStorages = subStorages.map { it.toStorage() },
-        creationTime = creationTime
+        creationTime = creationTime,
+        updatedAt = updatedAt,
     )
 }
 
@@ -118,6 +123,7 @@ private fun Storage.toNetworkStorage(depth: Int, maxDepth: Int?): NetworkStorage
         description = description,
         spaces = spaces.map { it.toNetworkSpace() },
         subStorages = subStorages,
-        creationTime = creationTime.format(DateTimeFormatter.ISO_DATE_TIME)
+        creationTime = creationTime.format(DateTimeFormatter.ISO_DATE_TIME),
+        updatedAt = updatedAt.format(DateTimeFormatter.ISO_DATE_TIME),
     )
 }

--- a/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
@@ -25,8 +25,8 @@ data class Storage(
     val spaces: List<Space>,
     val parentId: String?,
     val subStorages: List<Storage>,
-    val creationTime: LocalDateTime,
-    val updatedAt: LocalDateTime,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
 )
 
 @Serializable
@@ -36,8 +36,8 @@ data class NetworkStorage(
     val description: String,
     val spaces: List<NetworkSpace>,
     val subStorages: List<NetworkStorage>,
-    val creationTime: String,
-    val updatedAt: String,
+    val createdAt: String,
+    val updatedAt: String?
 )
 
 @Serializable
@@ -55,8 +55,8 @@ data class MoveStorageRequest(
 object Storages: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
-    val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
-    val updatedAt = datetime("updatedAt").defaultExpression(CurrentDateTime)
+    val createdAt = datetime("createdAt").defaultExpression(CurrentDateTime)
+    val updatedAt = datetime("updatedAt").nullable()
 }
 
 object StorageToStorages: Table() {
@@ -85,7 +85,7 @@ class StorageEntity(id: EntityID<UUID>) : UUIDEntity(id) {
                 }
             }
         }
-    var creationTime by Storages.creationTime
+    var createdAt by Storages.createdAt
     var updatedAt by Storages.updatedAt
 
     override fun delete() {
@@ -104,7 +104,7 @@ fun StorageEntity.toStorage(): Storage {
         spaces = spaces.map { it.toSpace() },
         parentId = parent?.id?.value?.toString(),
         subStorages = subStorages.map { it.toStorage() },
-        creationTime = creationTime,
+        createdAt = createdAt,
         updatedAt = updatedAt,
     )
 }
@@ -123,7 +123,7 @@ private fun Storage.toNetworkStorage(depth: Int, maxDepth: Int?): NetworkStorage
         description = description,
         spaces = spaces.map { it.toNetworkSpace() },
         subStorages = subStorages,
-        creationTime = creationTime.format(DateTimeFormatter.ISO_DATE_TIME),
-        updatedAt = updatedAt.format(DateTimeFormatter.ISO_DATE_TIME),
+        createdAt = createdAt.format(DateTimeFormatter.ISO_DATE_TIME),
+        updatedAt = updatedAt?.format(DateTimeFormatter.ISO_DATE_TIME),
     )
 }

--- a/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
 import org.jetbrains.exposed.sql.javatime.datetime
 import org.jetbrains.exposed.sql.selectAll
 import java.time.LocalDateTime
@@ -52,7 +53,7 @@ data class MoveStorageRequest(
 object Storages: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
-    val creationTime = datetime("creationTime")
+    val creationTime = datetime("creationTime").defaultExpression(CurrentDateTime)
 }
 
 object StorageToStorages: Table() {

--- a/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
@@ -12,7 +12,7 @@ import io.github.lagersystembackend.space.toSpace
 import io.github.lagersystembackend.storage.StorageEntity
 import io.github.lagersystembackend.storage.StorageToStorages
 import io.github.lagersystembackend.storage.Storages
-import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.date.shouldBeBefore
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -20,6 +20,7 @@ import io.ktor.server.testing.*
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -69,12 +70,15 @@ class PostgresProductRepositoryTest {
             LocalDateTime.now()
         )
 
+
         expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }.apply {
             name shouldBe expectedProduct.name
             description shouldBe expectedProduct.description
             spaceId shouldBe expectedProduct.spaceId
-            creationTime shouldBeEqual updatedAt
+            createdAt shouldBeBefore LocalDateTime.now()
+            updatedAt shouldBe null
         }
+
     }
 
     @Test
@@ -221,11 +225,11 @@ class PostgresProductRepositoryTest {
             "new description",
             emptyMap(),
             secondSpaceId.toString(),
-            createdProduct.creationTime,
+            createdProduct.createdAt,
             updatedProduct!!.updatedAt
         )
 
-        createdProduct.updatedAt shouldBeLessThan updatedProduct.updatedAt
+        createdProduct.createdAt shouldBeBefore updatedProduct.updatedAt!!
     }
 
     @Test
@@ -242,8 +246,7 @@ class PostgresProductRepositoryTest {
         val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
         val updatedProduct = sut.updateProduct(createdProduct.id, null, null, null)
 
-        updatedProduct shouldBe createdProduct.copy(updatedAt = updatedProduct!!.updatedAt)
-        createdProduct.updatedAt shouldBeLessThan updatedProduct.updatedAt
+        createdProduct.createdAt shouldBeBefore updatedProduct?.updatedAt!!
     }
 
     @Test
@@ -388,7 +391,7 @@ class PostgresProductRepositoryTest {
             createdProduct.description,
             emptyMap(),
             secondSpaceId.toString(),
-            createdProduct.creationTime,
+            createdProduct.createdAt,
             movedProduct!!.updatedAt
         )
     }
@@ -417,7 +420,7 @@ class PostgresProductRepositoryTest {
         val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
         val movedProduct = sut.moveProduct(createdProduct.id, secondSpaceId.toString())
 
-        createdProduct.updatedAt shouldBeLessThan movedProduct!!.updatedAt
+        createdProduct.createdAt shouldBeBefore movedProduct?.updatedAt!!
     }
 
     @Test

--- a/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.*
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -61,7 +62,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
 
         expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }.apply {
@@ -78,7 +80,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            UUID.randomUUID().toString()
+            UUID.randomUUID().toString(),
+            LocalDateTime.now()
         )
         runCatching {
             expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }
@@ -96,7 +99,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            "Invalid UUID"
+            "Invalid UUID",
+            LocalDateTime.now()
         )
         runCatching {
             expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }
@@ -114,7 +118,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         val createdProduct = expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }
         sut.getProduct(createdProduct.id) shouldBe createdProduct
@@ -145,7 +150,8 @@ class PostgresProductRepositoryTest {
                 "name1",
                 "description",
                 emptyMap(),
-                spaceId.toString()
+                spaceId.toString(),
+                LocalDateTime.now()
             ),
             Product(
                 "any id",
@@ -156,14 +162,16 @@ class PostgresProductRepositoryTest {
                     "someOtherKey" to Attribute.StringAttribute("some text"),
                     "someBooleanKey" to Attribute.BooleanAttribute(true)
                 ),
-                spaceId.toString()
+                spaceId.toString(),
+                LocalDateTime.now()
             ),
             Product(
                 "any id",
                 "name3",
                 "description",
                 emptyMap(),
-                spaceId.toString()
+                spaceId.toString(),
+                LocalDateTime.now()
             )
         )
         expectedProducts = expectedProducts.map { it.run { sut.createProduct(name, description, spaceId) } }
@@ -182,7 +190,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         val secondSpaceId = UUID.randomUUID()
         transaction {
@@ -200,7 +209,8 @@ class PostgresProductRepositoryTest {
             "new name",
             "new description",
             emptyMap(),
-            secondSpaceId.toString()
+            secondSpaceId.toString(),
+            createdProduct.creationTime
         )
     }
 
@@ -211,7 +221,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
         val updatedProduct = sut.updateProduct(createdProduct.id, null, null, null)
@@ -247,7 +258,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         product.run { sut.createProduct(name, description, spaceId.toString()) }
         runCatching {
@@ -266,7 +278,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
         runCatching {
@@ -285,7 +298,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
         sut.deleteProduct(createdProduct.id) shouldBe createdProduct
@@ -332,7 +346,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
 
         val secondSpaceId = UUID.randomUUID()
@@ -352,7 +367,8 @@ class PostgresProductRepositoryTest {
             createdProduct.name,
             createdProduct.description,
             emptyMap(),
-            secondSpaceId.toString()
+            secondSpaceId.toString(),
+            createdProduct.creationTime
         )
     }
 
@@ -376,7 +392,8 @@ class PostgresProductRepositoryTest {
             "name",
             "description",
             emptyMap(),
-            spaceId.toString()
+            spaceId.toString(),
+            LocalDateTime.now()
         )
         val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
         runCatching {

--- a/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.serialization.json.Json
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -44,8 +45,8 @@ class ProductRoutesKtTest {
     fun `get Products should respond with List of NetworkProducts`() = testApplication {
         createEnvironment()
         val products = listOf(
-            Product(UUID.randomUUID().toString(), "Space 1",  "Description 1",  emptyMap(), UUID.randomUUID().toString()),
-            Product(UUID.randomUUID().toString(), "Space 2", "Description 2", mapOf("someKey" to Attribute.NumberAttribute(123f)), UUID.randomUUID().toString())
+            Product(UUID.randomUUID().toString(), "Space 1",  "Description 1",  emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now()),
+            Product(UUID.randomUUID().toString(), "Space 2", "Description 2", mapOf("someKey" to Attribute.NumberAttribute(123f)), UUID.randomUUID().toString(), LocalDateTime.now())
         )
         every { mockProductRepository.getProducts() } returns products
         client.get("/products").apply {
@@ -69,7 +70,7 @@ class ProductRoutesKtTest {
     fun `get Product by ID should respond with NetworkProduct`() = testApplication {
         createEnvironment()
         val product1 =
-            Product(UUID.randomUUID().toString(), "Space 1", "Description 1", emptyMap(), UUID.randomUUID().toString())
+            Product(UUID.randomUUID().toString(), "Space 1", "Description 1", emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now())
         every { mockProductRepository.getProduct(product1.id) } returns product1
         client.get("/products/${product1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -106,7 +107,7 @@ class ProductRoutesKtTest {
     @Test
     fun `delete Product should delete Product`() = testApplication {
         createEnvironment()
-        val product1 = Product(UUID.randomUUID().toString(), "Product 1", "Description 1", emptyMap(), "any id")
+        val product1 = Product(UUID.randomUUID().toString(), "Product 1", "Description 1", emptyMap(), "any id", LocalDateTime.now())
         every { mockProductRepository.deleteProduct(product1.id) } returns product1
         client.delete("/products/${product1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -145,6 +146,7 @@ class ProductRoutesKtTest {
     @Test
     fun `post Product should create Product`() = testApplication {
         createEnvironment()
+        val createTime = LocalDateTime.now()
         val client = createClient {
             install(ContentNegotiation) {
                 json()
@@ -154,7 +156,7 @@ class ProductRoutesKtTest {
         val addProductNetworkRequest =
             AddProductNetworkRequest("Product 1", "Description 1", UUID.randomUUID().toString())
         addProductNetworkRequest.run {
-            val product = Product(id, name, description, emptyMap(), spaceId)
+            val product = Product(id, name, description, emptyMap(), spaceId, createTime)
             every { mockProductRepository.createProduct(name, description, spaceId) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
@@ -170,7 +172,8 @@ class ProductRoutesKtTest {
                     addProductNetworkRequest.name,
                     addProductNetworkRequest.description,
                     emptyMap(),
-                    addProductNetworkRequest.spaceId
+                    addProductNetworkRequest.spaceId,
+                    createTime
                 ).toNetworkProduct()
             Json.decodeFromString<NetworkProduct>(bodyAsText()) shouldBe expectedResponse
 
@@ -180,6 +183,7 @@ class ProductRoutesKtTest {
     @Test
     fun `post Product should create Product when price is null`() = testApplication {
         createEnvironment()
+        val createTime = LocalDateTime.now()
         val client = createClient {
             install(ContentNegotiation) {
                 json()
@@ -189,7 +193,7 @@ class ProductRoutesKtTest {
         val addProductNetworkRequest =
             AddProductNetworkRequest("Space 1", "Description 1", UUID.randomUUID().toString())
         addProductNetworkRequest.run {
-            val product = Product(id, name, description, emptyMap(), spaceId)
+            val product = Product(id, name, description, emptyMap(), spaceId, createTime)
             every { mockProductRepository.createProduct(name, description, spaceId) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
@@ -205,7 +209,8 @@ class ProductRoutesKtTest {
                     addProductNetworkRequest.name,
                     addProductNetworkRequest.description,
                     emptyMap(),
-                    addProductNetworkRequest.spaceId
+                    addProductNetworkRequest.spaceId,
+                    createTime
                 ).toNetworkProduct()
             Json.decodeFromString<NetworkProduct>(bodyAsText()) shouldBe expectedResponse
 

--- a/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
@@ -45,8 +45,8 @@ class ProductRoutesKtTest {
     fun `get Products should respond with List of NetworkProducts`() = testApplication {
         createEnvironment()
         val products = listOf(
-            Product(UUID.randomUUID().toString(), "Space 1",  "Description 1",  emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now()),
-            Product(UUID.randomUUID().toString(), "Space 2", "Description 2", mapOf("someKey" to Attribute.NumberAttribute(123f)), UUID.randomUUID().toString(), LocalDateTime.now())
+            Product(UUID.randomUUID().toString(), "Space 1",  "Description 1",  emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now()),
+            Product(UUID.randomUUID().toString(), "Space 2", "Description 2", mapOf("someKey" to Attribute.NumberAttribute(123f)), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now())
         )
         every { mockProductRepository.getProducts() } returns products
         client.get("/products").apply {
@@ -70,7 +70,7 @@ class ProductRoutesKtTest {
     fun `get Product by ID should respond with NetworkProduct`() = testApplication {
         createEnvironment()
         val product1 =
-            Product(UUID.randomUUID().toString(), "Space 1", "Description 1", emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now())
+            Product(UUID.randomUUID().toString(), "Space 1", "Description 1", emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now())
         every { mockProductRepository.getProduct(product1.id) } returns product1
         client.get("/products/${product1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -107,7 +107,7 @@ class ProductRoutesKtTest {
     @Test
     fun `delete Product should delete Product`() = testApplication {
         createEnvironment()
-        val product1 = Product(UUID.randomUUID().toString(), "Product 1", "Description 1", emptyMap(), "any id", LocalDateTime.now())
+        val product1 = Product(UUID.randomUUID().toString(), "Product 1", "Description 1", emptyMap(), "any id", LocalDateTime.now(), LocalDateTime.now())
         every { mockProductRepository.deleteProduct(product1.id) } returns product1
         client.delete("/products/${product1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -156,7 +156,7 @@ class ProductRoutesKtTest {
         val addProductNetworkRequest =
             AddProductNetworkRequest("Product 1", "Description 1", UUID.randomUUID().toString())
         addProductNetworkRequest.run {
-            val product = Product(id, name, description, emptyMap(), spaceId, createTime)
+            val product = Product(id, name, description, emptyMap(), spaceId, createTime, createTime)
             every { mockProductRepository.createProduct(name, description, spaceId) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
@@ -173,6 +173,7 @@ class ProductRoutesKtTest {
                     addProductNetworkRequest.description,
                     emptyMap(),
                     addProductNetworkRequest.spaceId,
+                    createTime,
                     createTime
                 ).toNetworkProduct()
             Json.decodeFromString<NetworkProduct>(bodyAsText()) shouldBe expectedResponse
@@ -193,7 +194,7 @@ class ProductRoutesKtTest {
         val addProductNetworkRequest =
             AddProductNetworkRequest("Space 1", "Description 1", UUID.randomUUID().toString())
         addProductNetworkRequest.run {
-            val product = Product(id, name, description, emptyMap(), spaceId, createTime)
+            val product = Product(id, name, description, emptyMap(), spaceId, createTime, createTime)
             every { mockProductRepository.createProduct(name, description, spaceId) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
@@ -210,6 +211,7 @@ class ProductRoutesKtTest {
                     addProductNetworkRequest.description,
                     emptyMap(),
                     addProductNetworkRequest.spaceId,
+                    createTime,
                     createTime
                 ).toNetworkProduct()
             Json.decodeFromString<NetworkProduct>(bodyAsText()) shouldBe expectedResponse

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -8,7 +8,7 @@ import io.github.lagersystembackend.product.Products
 import io.github.lagersystembackend.storage.StorageEntity
 import io.github.lagersystembackend.storage.StorageToStorages
 import io.github.lagersystembackend.storage.Storages
-import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.date.shouldBeBefore
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -74,7 +74,8 @@ class PostgresSpaceRepositoryTest {
             size shouldBe expectedSpace.size
             description shouldBe expectedSpace.description
             storageId shouldBe expectedSpace.storageId
-            creationTime shouldBeEqual updatedAt
+            createdAt shouldBeBefore LocalDateTime.now()
+            updatedAt shouldBe null
         }
     }
 
@@ -131,7 +132,7 @@ class PostgresSpaceRepositoryTest {
             this shouldBe updatedSpace
             name shouldBe "newName"
             description shouldBe createdSpace.description
-            createdSpace.updatedAt shouldBeLessThan updatedSpace!!.updatedAt
+            createdSpace.createdAt shouldBeBefore updatedSpace?.updatedAt!!
         }
     }
 
@@ -206,10 +207,10 @@ class PostgresSpaceRepositoryTest {
 
     @Test
     fun `moveSpace should update updatedAt timestamp`() = testApplication {
-        val createdSpace = insertSpace()
+        val createdSpace = insertSpace().copy(updatedAt = LocalDateTime.now())
         val movedSpace = sut.moveSpace(createdSpace.id, targetStorageId.toString())
 
-        createdSpace.updatedAt shouldBeLessThan movedSpace.updatedAt
+        createdSpace.createdAt shouldBeBefore movedSpace.updatedAt!!
     }
 
     @Test

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.testApplication
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -62,7 +63,7 @@ class PostgresSpaceRepositoryTest {
     @Test
     fun `create Space should return Space`() = testApplication {
         val expectedSpace =
-            Space("anyId", "Space", 100f,"Space description", emptyList(), exampleStorageId.toString())
+            Space("anyId", "Space", 100f,"Space description", emptyList(), exampleStorageId.toString(), LocalDateTime.now())
         val createdStorage = expectedSpace.run { sut.createSpace(name, size, description, storageId) }
 
         createdStorage.apply {
@@ -108,13 +109,14 @@ class PostgresSpaceRepositoryTest {
 
     @Test
     fun `get Spaces should return List of Spaces`() = testApplication {
+        val createTime = LocalDateTime.now()
         val expectedSpaces = listOf(
-            Space("anyId", "Space1", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString()),
-            Space("anyId", "Space2", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString()),
-            Space("anyId", "Space3", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString())
+            Space("anyId", "Space1", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime),
+            Space("anyId", "Space2", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime),
+            Space("anyId", "Space3", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime)
         )
-        val createdStorages = expectedSpaces.map { it.run { sut.createSpace(name, size, description, storageId) } }
-        sut.getSpaces() shouldBe createdStorages
+        val createdSpaces = expectedSpaces.map { it.run { sut.createSpace(name, size, description, storageId) } }
+        sut.getSpaces() shouldBe createdSpaces
     }
 
     @Test
@@ -172,9 +174,9 @@ class PostgresSpaceRepositoryTest {
     fun `delete Space should delete products`() = testApplication {
         val createdSpace = insertSpace()
         val products = listOf(
-            Product("anyId", "Product1", "Space description", emptyMap(), createdSpace.id),
-            Product("anyId", "Product2", "Space description", emptyMap(), createdSpace.id),
-            Product("anyId", "Product3", "Space description", emptyMap(), createdSpace.id)
+            Product("anyId", "Product1", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now()),
+            Product("anyId", "Product2", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now()),
+            Product("anyId", "Product3", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now())
         )
         val productRepository = PostgresProductRepository()
         val createdProducts = products.map { it.run { productRepository.createProduct(name, description, spaceId) } }
@@ -242,9 +244,9 @@ class PostgresSpaceRepositoryTest {
     fun `moveSpace should keep products after move`() = testApplication {
         val createdSpace = insertSpace()
         val products = listOf(
-            Product("anyId", "Product1", "Space description", emptyMap(), createdSpace.id),
-            Product("anyId", "Product2", "Space description", emptyMap(), createdSpace.id),
-            Product("anyId", "Product3", "Space description", emptyMap(), createdSpace.id)
+            Product("anyId", "Product1", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now()),
+            Product("anyId", "Product2", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now()),
+            Product("anyId", "Product3", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now())
         )
         val productRepository = PostgresProductRepository()
         val createdProducts = products.map { it.run { productRepository.createProduct(name, description, createdSpace.id) } }

--- a/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.serialization.json.Json
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -41,8 +42,8 @@ class SpaceRoutesKtTest {
     fun `get Spaces should respond with List of NetworkSpaces`() = testApplication {
         createEnvironment()
         val spaces = listOf(
-            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf()),
-            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf())
+            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now()),
+            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now())
         )
         every { mockSpaceRepository.getSpaces() } returns spaces
         client.get("/spaces").apply {
@@ -65,7 +66,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `get Space by ID should respond with NetworkSpace`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now())
         every { mockSpaceRepository.getSpace(space1.id) } returns space1
         client.get("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -102,7 +103,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `delete Space should delete Space`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now())
         every { mockSpaceRepository.deleteSpace(space1.id) } returns space1
         client.delete("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -151,7 +152,7 @@ class SpaceRoutesKtTest {
         val storageId = UUID.randomUUID().toString()
         val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", 100f, "Description 1", storageId = storageId)
         addSpaceNetworkRequest.run {
-            val space = Space(id, name, size, description, products = listOf(), storageId)
+            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now())
             every { mockSpaceRepository.createSpace(name, size, description, storageId) } returns space
             every { mockStorageRepository.storageExists(storageId) } returns true
             client.post("/spaces") {
@@ -177,7 +178,7 @@ class SpaceRoutesKtTest {
         val storageId = UUID.randomUUID().toString()
         val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", null, "Description 1", storageId = storageId)
         addSpaceNetworkRequest.run {
-            val space = Space(id, name, size, description, products = listOf(), storageId)
+            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now())
             every { mockSpaceRepository.createSpace(name, size, description, storageId) } returns space
             every { mockStorageRepository.storageExists(storageId) } returns true
             client.post("/spaces") {

--- a/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
@@ -42,8 +42,8 @@ class SpaceRoutesKtTest {
     fun `get Spaces should respond with List of NetworkSpaces`() = testApplication {
         createEnvironment()
         val spaces = listOf(
-            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now()),
-            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now())
+            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         )
         every { mockSpaceRepository.getSpaces() } returns spaces
         client.get("/spaces").apply {
@@ -66,7 +66,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `get Space by ID should respond with NetworkSpace`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockSpaceRepository.getSpace(space1.id) } returns space1
         client.get("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -103,7 +103,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `delete Space should delete Space`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockSpaceRepository.deleteSpace(space1.id) } returns space1
         client.delete("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -152,7 +152,7 @@ class SpaceRoutesKtTest {
         val storageId = UUID.randomUUID().toString()
         val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", 100f, "Description 1", storageId = storageId)
         addSpaceNetworkRequest.run {
-            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now())
+            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now(), LocalDateTime.now())
             every { mockSpaceRepository.createSpace(name, size, description, storageId) } returns space
             every { mockStorageRepository.storageExists(storageId) } returns true
             client.post("/spaces") {
@@ -178,7 +178,7 @@ class SpaceRoutesKtTest {
         val storageId = UUID.randomUUID().toString()
         val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", null, "Description 1", storageId = storageId)
         addSpaceNetworkRequest.run {
-            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now())
+            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now(), LocalDateTime.now())
             every { mockSpaceRepository.createSpace(name, size, description, storageId) } returns space
             every { mockStorageRepository.storageExists(storageId) } returns true
             client.post("/spaces") {

--- a/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
@@ -42,8 +42,8 @@ class SpaceRoutesKtTest {
     fun `get Spaces should respond with List of NetworkSpaces`() = testApplication {
         createEnvironment()
         val spaces = listOf(
-            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
-            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         )
         every { mockSpaceRepository.getSpaces() } returns spaces
         client.get("/spaces").apply {
@@ -66,7 +66,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `get Space by ID should respond with NetworkSpace`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockSpaceRepository.getSpace(space1.id) } returns space1
         client.get("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -103,7 +103,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `delete Space should delete Space`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockSpaceRepository.deleteSpace(space1.id) } returns space1
         client.delete("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK

--- a/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
@@ -7,7 +7,7 @@ import io.github.lagersystembackend.space.PostgresSpaceRepository
 import io.github.lagersystembackend.space.Space
 import io.github.lagersystembackend.space.Spaces
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.date.shouldBeBefore
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -57,7 +57,8 @@ class PostgresStorageRepositoryTest {
             name shouldBe expectedStorage.name
             description shouldBe expectedStorage.description
             parentId shouldBe expectedStorage.parentId
-            creationTime shouldBeEqual updatedAt
+            createdAt shouldBeBefore LocalDateTime.now()
+            updatedAt shouldBe null
         }
         sut.getStorage(rootStorage.id)!!.subStorages shouldContain createdStorage
     }
@@ -98,9 +99,9 @@ class PostgresStorageRepositoryTest {
     @Test
     fun `get Storages should return List of Storages`() = testApplication {
         val expectedStorages = listOf(
-            Storage("anyId", "root1", "Storage description", spaces = emptyList(), parentId = null, subStorages =  emptyList(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
-            Storage("anyId", "root2", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
-            Storage("anyId", "root3", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            Storage("anyId", "root1", "Storage description", spaces = emptyList(), parentId = null, subStorages =  emptyList(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Storage("anyId", "root2", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Storage("anyId", "root3", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         )
         val createdStorages = expectedStorages.map { it.run { sut.createStorage(name, description, parentId) } }
         sut.getStorages() shouldBe createdStorages
@@ -114,7 +115,7 @@ class PostgresStorageRepositoryTest {
             this shouldBe updatedStorage
             name shouldBe "newName"
             description shouldBe rootStorage.description
-            rootStorage.updatedAt shouldBeLessThan updatedStorage!!.updatedAt
+            rootStorage.createdAt shouldBeBefore updatedStorage?.updatedAt!!
         }
     }
 
@@ -225,7 +226,7 @@ class PostgresStorageRepositoryTest {
 
         val movedStorage = sut.moveStorage(subStorage.id, newParentStorage.id)
 
-        rootStorage.updatedAt shouldBeLessThan movedStorage.updatedAt
+        rootStorage.createdAt shouldBeBefore movedStorage.updatedAt!!
     }
 
     @Test

--- a/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.testApplication
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -47,7 +48,7 @@ class PostgresStorageRepositoryTest {
     fun `create Storage should return Storage`() = testApplication {
         val rootStorage = insertRootStorage()
         val expectedStorage =
-            Storage("anyId", "Storage", "Storage description", emptyList(), rootStorage.id, emptyList())
+            Storage("anyId", "Storage", "Storage description", emptyList(), rootStorage.id, emptyList(), LocalDateTime.now())
         val createdStorage = expectedStorage.run { sut.createStorage(name, description, parentId) }
 
         createdStorage.apply {
@@ -94,9 +95,9 @@ class PostgresStorageRepositoryTest {
     @Test
     fun `get Storages should return List of Storages`() = testApplication {
         val expectedStorages = listOf(
-            Storage("anyId", "root1", "Storage description", spaces = emptyList(), parentId = null, subStorages =  emptyList()),
-            Storage("anyId", "root2", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList()),
-            Storage("anyId", "root3", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList())
+            Storage("anyId", "root1", "Storage description", spaces = emptyList(), parentId = null, subStorages =  emptyList(), creationTime = LocalDateTime.now()),
+            Storage("anyId", "root2", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList(), creationTime = LocalDateTime.now()),
+            Storage("anyId", "root3", "Storage description", spaces = emptyList(), parentId = null, subStorages = emptyList(), creationTime = LocalDateTime.now())
         )
         val createdStorages = expectedStorages.map { it.run { sut.createStorage(name, description, parentId) } }
         sut.getStorages() shouldBe createdStorages
@@ -169,9 +170,9 @@ class PostgresStorageRepositoryTest {
     fun `delete Storage should delete spaces`() = testApplication {
         val rootStorage = insertRootStorage()
         val spaces = listOf(
-            Space("anyId", "Space1", 100f, "Space description", emptyList(), rootStorage.id),
-            Space("anyId", "Space2", 200f, "Space description", emptyList(), rootStorage.id),
-            Space("anyId", "Space3", 300f, "Space description", emptyList(), rootStorage.id)
+            Space("anyId", "Space1", 100f, "Space description", emptyList(), rootStorage.id, LocalDateTime.now()),
+            Space("anyId", "Space2", 200f, "Space description", emptyList(), rootStorage.id, LocalDateTime.now()),
+            Space("anyId", "Space3", 300f, "Space description", emptyList(), rootStorage.id, LocalDateTime.now())
         )
         val spaceRepository = PostgresSpaceRepository()
         val createdSpaces = spaces.map { it.run { spaceRepository.createSpace(name, size, description, storageId) } }

--- a/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
@@ -39,8 +39,8 @@ class StorageRoutesKtTest {
     fun `get Storages should respond with List of Parent NetworkStorages`() = testApplication {
         createEnviroment()
         val storages = listOf(
-            Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(),parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now()),
-            Storage(UUID.randomUUID().toString(), "Storage 2", "Description 2", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+            Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(),parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Storage(UUID.randomUUID().toString(), "Storage 2", "Description 2", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         )
         every { mockStorageRepository.getStorages() } returns storages
         client.get("/storages").apply {
@@ -75,7 +75,7 @@ class StorageRoutesKtTest {
     @Test
     fun `get Storage by ID should respond with NetworkStorage`() = testApplication {
         createEnviroment()
-        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockStorageRepository.getStorage(storage1.id) } returns storage1
         client.get("/storages/${storage1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -113,7 +113,7 @@ class StorageRoutesKtTest {
     fun `get Storage by id should respond with Bad Request when depth parameter is invalid`() = testApplication {
         createEnviroment()
         val id = UUID.randomUUID().toString()
-        val storage = Storage(id, "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+        val storage = Storage(id, "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockStorageRepository.getStorage(id) } returns storage
         client.get("/storages/${id}?depth=invalid").apply {
             status shouldBe HttpStatusCode.BadRequest
@@ -127,7 +127,7 @@ class StorageRoutesKtTest {
     @Test
     fun `delete Storage should delete Storage`() = testApplication {
         createEnviroment()
-        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockStorageRepository.deleteStorage(storage1.id) } returns storage1
         client.delete("/storages/${storage1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -173,7 +173,7 @@ class StorageRoutesKtTest {
         val id = UUID.randomUUID().toString()
         val addStorageNetworkRequest = AddStorageNetworkRequest("Storage 1", "Description 1", parentId = null)
         addStorageNetworkRequest.run {
-            val storage = Storage(id, name, description, spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+            val storage = Storage(id, name, description, spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
             every { mockStorageRepository.createStorage(name, description, parentId) } returns storage
             client.post("/storages") {
                 setBody(addStorageNetworkRequest)
@@ -245,8 +245,8 @@ class StorageRoutesKtTest {
         val parentId = UUID.randomUUID().toString()
         val addStorageNetworkRequest = AddStorageNetworkRequest("Storage 1", "Description 1", parentId = parentId)
         addStorageNetworkRequest.run {
-            val storageParent = Storage(parentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
-            val storage = Storage(UUID.randomUUID().toString(), name, description, spaces = listOf(), parentId = parentId, subStorages = listOf(), creationTime = LocalDateTime.now())
+            val storageParent = Storage(parentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            val storage = Storage(UUID.randomUUID().toString(), name, description, spaces = listOf(), parentId = parentId, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
             every { mockStorageRepository.getStorage(parentId) } returns storageParent
             every { mockStorageRepository.createStorage(name, description, parentId) } returns storage
             client.post("/storages") {
@@ -356,7 +356,7 @@ class StorageRoutesKtTest {
         val moveRequest = MoveStorageRequest(newParentId = newParentId)
 
         every { mockStorageRepository.getStorage(id) } returns Storage(
-            id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), LocalDateTime.now()
+            id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), LocalDateTime.now(), LocalDateTime.now()
         )
         every { mockStorageRepository.getStorage(newParentId) } returns null
 
@@ -384,8 +384,8 @@ class StorageRoutesKtTest {
         val newParentId = UUID.randomUUID().toString()
         val moveRequest = MoveStorageRequest(newParentId = newParentId)
 
-        val storageA = Storage(id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
-        val storageParent = Storage(newParentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+        val storageA = Storage(id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val storageParent = Storage(newParentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
 
         every { mockStorageRepository.getStorage(id) } returns storageA
         every { mockStorageRepository.getStorage(newParentId) } returns storageParent

--- a/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
@@ -16,6 +16,7 @@ import io.ktor.server.testing.*
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
+import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -38,8 +39,8 @@ class StorageRoutesKtTest {
     fun `get Storages should respond with List of Parent NetworkStorages`() = testApplication {
         createEnviroment()
         val storages = listOf(
-            Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(),parentId = null, subStorages = listOf()),
-            Storage(UUID.randomUUID().toString(), "Storage 2", "Description 2", spaces = listOf(), parentId = null, subStorages = listOf())
+            Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(),parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now()),
+            Storage(UUID.randomUUID().toString(), "Storage 2", "Description 2", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
         )
         every { mockStorageRepository.getStorages() } returns storages
         client.get("/storages").apply {
@@ -74,7 +75,7 @@ class StorageRoutesKtTest {
     @Test
     fun `get Storage by ID should respond with NetworkStorage`() = testApplication {
         createEnviroment()
-        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf())
+        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
         every { mockStorageRepository.getStorage(storage1.id) } returns storage1
         client.get("/storages/${storage1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -112,7 +113,7 @@ class StorageRoutesKtTest {
     fun `get Storage by id should respond with Bad Request when depth parameter is invalid`() = testApplication {
         createEnviroment()
         val id = UUID.randomUUID().toString()
-        val storage = Storage(id, "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf())
+        val storage = Storage(id, "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
         every { mockStorageRepository.getStorage(id) } returns storage
         client.get("/storages/${id}?depth=invalid").apply {
             status shouldBe HttpStatusCode.BadRequest
@@ -126,7 +127,7 @@ class StorageRoutesKtTest {
     @Test
     fun `delete Storage should delete Storage`() = testApplication {
         createEnviroment()
-        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf())
+        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
         every { mockStorageRepository.deleteStorage(storage1.id) } returns storage1
         client.delete("/storages/${storage1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -172,7 +173,7 @@ class StorageRoutesKtTest {
         val id = UUID.randomUUID().toString()
         val addStorageNetworkRequest = AddStorageNetworkRequest("Storage 1", "Description 1", parentId = null)
         addStorageNetworkRequest.run {
-            val storage = Storage(id, name, description, spaces = listOf(), parentId = null, subStorages = listOf())
+            val storage = Storage(id, name, description, spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
             every { mockStorageRepository.createStorage(name, description, parentId) } returns storage
             client.post("/storages") {
                 setBody(addStorageNetworkRequest)
@@ -244,8 +245,8 @@ class StorageRoutesKtTest {
         val parentId = UUID.randomUUID().toString()
         val addStorageNetworkRequest = AddStorageNetworkRequest("Storage 1", "Description 1", parentId = parentId)
         addStorageNetworkRequest.run {
-            val storageParent = Storage(parentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf())
-            val storage = Storage(UUID.randomUUID().toString(), name, description, spaces = listOf(), parentId = parentId, subStorages = listOf())
+            val storageParent = Storage(parentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+            val storage = Storage(UUID.randomUUID().toString(), name, description, spaces = listOf(), parentId = parentId, subStorages = listOf(), creationTime = LocalDateTime.now())
             every { mockStorageRepository.getStorage(parentId) } returns storageParent
             every { mockStorageRepository.createStorage(name, description, parentId) } returns storage
             client.post("/storages") {
@@ -355,7 +356,7 @@ class StorageRoutesKtTest {
         val moveRequest = MoveStorageRequest(newParentId = newParentId)
 
         every { mockStorageRepository.getStorage(id) } returns Storage(
-            id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf()
+            id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), LocalDateTime.now()
         )
         every { mockStorageRepository.getStorage(newParentId) } returns null
 
@@ -383,8 +384,8 @@ class StorageRoutesKtTest {
         val newParentId = UUID.randomUUID().toString()
         val moveRequest = MoveStorageRequest(newParentId = newParentId)
 
-        val storageA = Storage(id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf())
-        val storageParent = Storage(newParentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf())
+        val storageA = Storage(id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
+        val storageParent = Storage(newParentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now())
 
         every { mockStorageRepository.getStorage(id) } returns storageA
         every { mockStorageRepository.getStorage(newParentId) } returns storageParent

--- a/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
@@ -39,8 +39,8 @@ class StorageRoutesKtTest {
     fun `get Storages should respond with List of Parent NetworkStorages`() = testApplication {
         createEnviroment()
         val storages = listOf(
-            Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(),parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
-            Storage(UUID.randomUUID().toString(), "Storage 2", "Description 2", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(),parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Storage(UUID.randomUUID().toString(), "Storage 2", "Description 2", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         )
         every { mockStorageRepository.getStorages() } returns storages
         client.get("/storages").apply {
@@ -75,7 +75,7 @@ class StorageRoutesKtTest {
     @Test
     fun `get Storage by ID should respond with NetworkStorage`() = testApplication {
         createEnviroment()
-        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockStorageRepository.getStorage(storage1.id) } returns storage1
         client.get("/storages/${storage1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -113,7 +113,7 @@ class StorageRoutesKtTest {
     fun `get Storage by id should respond with Bad Request when depth parameter is invalid`() = testApplication {
         createEnviroment()
         val id = UUID.randomUUID().toString()
-        val storage = Storage(id, "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val storage = Storage(id, "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockStorageRepository.getStorage(id) } returns storage
         client.get("/storages/${id}?depth=invalid").apply {
             status shouldBe HttpStatusCode.BadRequest
@@ -127,7 +127,7 @@ class StorageRoutesKtTest {
     @Test
     fun `delete Storage should delete Storage`() = testApplication {
         createEnviroment()
-        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val storage1 = Storage(UUID.randomUUID().toString(), "Storage 1", "Description 1", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockStorageRepository.deleteStorage(storage1.id) } returns storage1
         client.delete("/storages/${storage1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -173,7 +173,7 @@ class StorageRoutesKtTest {
         val id = UUID.randomUUID().toString()
         val addStorageNetworkRequest = AddStorageNetworkRequest("Storage 1", "Description 1", parentId = null)
         addStorageNetworkRequest.run {
-            val storage = Storage(id, name, description, spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            val storage = Storage(id, name, description, spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
             every { mockStorageRepository.createStorage(name, description, parentId) } returns storage
             client.post("/storages") {
                 setBody(addStorageNetworkRequest)
@@ -245,8 +245,8 @@ class StorageRoutesKtTest {
         val parentId = UUID.randomUUID().toString()
         val addStorageNetworkRequest = AddStorageNetworkRequest("Storage 1", "Description 1", parentId = parentId)
         addStorageNetworkRequest.run {
-            val storageParent = Storage(parentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
-            val storage = Storage(UUID.randomUUID().toString(), name, description, spaces = listOf(), parentId = parentId, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            val storageParent = Storage(parentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            val storage = Storage(UUID.randomUUID().toString(), name, description, spaces = listOf(), parentId = parentId, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
             every { mockStorageRepository.getStorage(parentId) } returns storageParent
             every { mockStorageRepository.createStorage(name, description, parentId) } returns storage
             client.post("/storages") {
@@ -384,8 +384,8 @@ class StorageRoutesKtTest {
         val newParentId = UUID.randomUUID().toString()
         val moveRequest = MoveStorageRequest(newParentId = newParentId)
 
-        val storageA = Storage(id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
-        val storageParent = Storage(newParentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), creationTime = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val storageA = Storage(id, "Storage A", "Description A", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val storageParent = Storage(newParentId, "Storage Parent", "Description Parent", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
 
         every { mockStorageRepository.getStorage(id) } returns storageA
         every { mockStorageRepository.getStorage(newParentId) } returns storageParent


### PR DESCRIPTION
Ich habe zwei neue timestamps **_creationTime_** und **_updatedAt_** eingebaut. Diese geben an, wann ein Objekt erstellt bzw. das letzte Mal geupdated wurde.

Folgende Dinge sind zu beachten: 
- Die timestamps **_creationTime_** und **_updatedAt_** sind bei der Objekterstellung gleich
- Für beide timestamps gibt es einen default wert um batch inserting zu ermögichen (für Tests)
- Die precision wurde auf Mikrosekunden gestellt damit die Tests keine Probleme machen (minimale Abweichungen vermeiden)
- **_updatedAt_** wird sowohl bei update() als auch move() neu gesetzt

Die Anpassung der Präzision und die Default-werte waren also hauptsächlich für die Tests notwendig.
Falls euch dafür noch eine schönere Lösung einfällt, gibt mir gerne Bescheid.

Ansonsten bitte ich um ein Review.