### PR TITLE
68 create a function to copy products storages and spaces

### DIFF
--- a/src/main/kotlin/io/github/lagersystembackend/common/ApiResponse.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/common/ApiResponse.kt
@@ -25,4 +25,6 @@ object ErrorMessages {
     val BODY_NOT_SERIALIZED_SPACE = ApiError("BODY_NOT_SERIALIZED" , "The request of specified space is not in the expected format.")
     val BODY_NOT_SERIALIZED_PRODUCT = ApiError("BODY_NOT_SERIALIZED" , "The request of specified product is not in the expected format.")
     val INVALID_DEPTH = ApiError("INVALID_DEPTH" , "The provided depth parameter is invalid.")
+    val RECURSIVE_MOVE = ApiError("RECURSIVE_MOVE" , "Cannot move storage to itself.")
+    val RECURSIVE_COPY = ApiError("RECURSIVE_COPY" , "Cannot copy storage to itself.")
 }

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -1,5 +1,6 @@
 package io.github.lagersystembackend.product
 import io.github.lagersystembackend.space.SpaceEntity
+import io.github.lagersystembackend.attribute.ProductAttributeEntity
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.UUID
 
@@ -51,4 +52,29 @@ class PostgresProductRepository : ProductRepository {
         ProductEntity.findById(UUID.fromString(id)).also { it?.delete() }?.toProduct()
     }
 
+    override fun copyProduct(productId: String, targetSpaceId: String): Product {
+        return transaction {
+
+            val originalProduct = ProductEntity.findById(UUID.fromString(productId))
+                ?: throw IllegalArgumentException("Product with ID $productId not found")
+
+            val targetSpace = SpaceEntity.findById(UUID.fromString(targetSpaceId))
+                ?: throw IllegalArgumentException("Space with ID $targetSpaceId not found")
+
+            val newProductEntity = ProductEntity.new {
+                name = originalProduct.name + " (Copy)"
+                description = originalProduct.description
+                space = targetSpace
+            }
+
+            originalProduct.attributes.forEach { attribute ->
+                ProductAttributeEntity.new {
+                    key = attribute.key
+                    value = attribute.value
+                    product = newProductEntity
+                }
+            }
+            newProductEntity.toProduct()
+        }
+    }
 }

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -64,7 +64,7 @@ class PostgresProductRepository : ProductRepository {
                 ?: throw IllegalArgumentException("Space with ID $targetSpaceId not found")
 
             val newProductEntity = ProductEntity.new {
-                name = originalProduct.name + " (Copy)"
+                name = originalProduct.name
                 description = originalProduct.description
                 space = targetSpace
             }

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -38,6 +38,10 @@ data class AddProductNetworkRequest(
     val spaceId: String
 )
 
+@Serializable
+data class CopyProductRequest(
+    val targetSpaceId: String
+)
 
 object Products: UUIDTable() {
     val name = varchar("name", 255)

--- a/src/main/kotlin/io/github/lagersystembackend/product/ProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/ProductRepository.kt
@@ -7,4 +7,5 @@ interface ProductRepository {
     fun updateProduct(id: String, name: String?, description: String?, spaceId: String?): Product?
     fun deleteProduct(id: String): Product?
     fun moveProduct(id: String, spaceId: String): Product?
+    fun copyProduct(productId: String, targetSpaceId: String): Product
 }

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -80,14 +80,14 @@ class PostgresSpaceRepository : SpaceRepository {
                 ?: throw IllegalArgumentException("Storage with ID $targetStorageId not found")
 
             val newSpaceEntity = SpaceEntity.new {
-                name = originalSpace.name + " (Copy)"
+                name = originalSpace.name
                 size = originalSpace.size
                 description = originalSpace.description
                 storage = targetStorage
             }
             originalSpace.products.forEach { product ->
                 val newProductEntity = ProductEntity.new {
-                    name = product.name + " (Copy)"
+                    name = product.name
                     description = product.description
                     this.space = newSpaceEntity
                 }

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -48,6 +48,11 @@ data class MoveSpaceRequest(
     val targetStorageId: String
 )
 
+@Serializable
+data class CopySpaceRequest(
+    val targetStorageId: String
+)
+
 object Spaces: UUIDTable() {
     val name = varchar("name", 255)
     val size = float("size").nullable()

--- a/src/main/kotlin/io/github/lagersystembackend/space/SpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/SpaceRepository.kt
@@ -8,4 +8,5 @@ interface SpaceRepository {
     fun deleteSpace(id: String): Space?
     fun spaceExists(id: String): Boolean
     fun moveSpace(spaceId: String, targetStorageId: String): Space
+    fun copySpace(spaceId: String, targetStorageId: String): Space
 }

--- a/src/main/kotlin/io/github/lagersystembackend/space/SpaceRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/SpaceRoutes.kt
@@ -138,7 +138,6 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
                     call.respond(HttpStatusCode.Created, copiedSpace.toNetworkSpace())
                 }
             }
-
         }
 
         post {

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -60,6 +60,10 @@ class PostgresStorageRepository: StorageRepository {
     }
 
     override fun moveStorage(id: String, newParentId: String?): Storage = transaction {
+        if (id == newParentId) {
+            throw IllegalArgumentException("Cannot move storage to itself")
+        }
+
         val storage = StorageEntity.findById(UUID.fromString(id))
             ?: throw IllegalArgumentException("Storage with ID $id not found")
 

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -96,6 +96,10 @@ class PostgresStorageRepository: StorageRepository {
     override fun copyStorage(id: String, newParentId: String?): Storage {
         return transaction {
 
+            if (id == newParentId) {
+                throw IllegalArgumentException("Cannot copy storage to itself")
+            }
+
             val originalStorage = StorageEntity.findById(UUID.fromString(id))
                 ?: throw IllegalArgumentException("Storage with ID $id not found")
 
@@ -105,7 +109,7 @@ class PostgresStorageRepository: StorageRepository {
             }
 
             val newStorageEntity = StorageEntity.new {
-                name = originalStorage.name + " (Copy)"
+                name = originalStorage.name
                 description = originalStorage.description
             }
 
@@ -113,14 +117,14 @@ class PostgresStorageRepository: StorageRepository {
 
             originalStorage.spaces.forEach { space ->
                 val newSpaceEntity = SpaceEntity.new {
-                    name = space.name + " (Copy)"
+                    name = space.name 
                     size = space.size
                     description = space.description
                     storage = newStorageEntity
                 }
                 space.products.forEach { product ->
                     val newProductEntity = ProductEntity.new {
-                        name = product.name + " (Copy)"
+                        name = product.name 
                         description = product.description
                         this.space = newSpaceEntity
                     }

--- a/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
@@ -44,6 +44,11 @@ data class MoveStorageRequest(
     val newParentId: String?
 )
 
+@Serializable
+data class CopyStorageRequest(
+    val newParentId: String? = null
+)
+
 object Storages: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")

--- a/src/main/kotlin/io/github/lagersystembackend/storage/StorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/StorageRepository.kt
@@ -9,4 +9,5 @@ interface StorageRepository {
     fun storageExists(id: String): Boolean
     fun moveStorage(id: String, newParentId: String?): Storage
     fun isCircularReference(storageId: String, targetParentId: String): Boolean
+    fun copyStorage(id: String, newParentId: String?): Storage
 }

--- a/src/main/kotlin/io/github/lagersystembackend/storage/StorageRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/StorageRoutes.kt
@@ -128,7 +128,10 @@ fun Route.storageRoutes(storageRepository: StorageRepository) {
                     if (targetParentId != null) {
                         if (!targetParentId.isUUID()) {
                             errors.add(ErrorMessages.INVALID_UUID_STORAGE)
-                        } else {
+                        } else if (id == targetParentId) {
+                            errors.add(ErrorMessages.RECURSIVE_MOVE)
+                        }
+                        else {
                             if (!storageRepository.storageExists(targetParentId)) {
                                 errors.add(ErrorMessages.STORAGE_NOT_FOUND.withContext("ID: $targetParentId"))
                             }
@@ -169,6 +172,8 @@ fun Route.storageRoutes(storageRepository: StorageRepository) {
                     if (newParentId != null) {
                         if (!newParentId.isUUID()) {
                             errors.add(ErrorMessages.INVALID_UUID_STORAGE)
+                        } else if (id == newParentId) {
+                            errors.add(ErrorMessages.RECURSIVE_COPY)
                         } else {
                             val targetStorage = storageRepository.getStorage(newParentId)
                             if (targetStorage == null) {

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -474,6 +474,58 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkStorage"
+  /v1/storages/{id}/copy:
+    post:
+      description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopyStorageRequest"
+        required: true
+      responses:
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+        "201":
+          description: "Created"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NetworkStorage"
   /v1/storages/{id}/move:
     post:
       description: ""
@@ -535,10 +587,9 @@ components:
           type: "string"
         name:
           type: "string"
-        price:
-          type: "number"
-          format: "float"
         description:
+          type: "string"
+        attributes:
           type: "string"
         spaceId:
           type: "string"
@@ -546,15 +597,13 @@ components:
       - "id"
       - "name"
       - "description"
+      - "attributes"
       - "spaceId"
     AddProductNetworkRequest:
       type: "object"
       properties:
         name:
           type: "string"
-        price:
-          type: "number"
-          format: "float"
         description:
           type: "string"
         spaceId:
@@ -665,6 +714,11 @@ components:
       required:
       - "name"
       - "description"
+    CopyStorageRequest:
+      type: "object"
+      properties:
+        newParentId:
+          type: "string"
     MoveStorageRequest:
       type: "object"
       properties:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -59,11 +59,11 @@ paths:
     delete:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -96,11 +96,11 @@ paths:
     get:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -134,11 +134,11 @@ paths:
     patch:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -190,11 +190,11 @@ paths:
     patch:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -276,11 +276,11 @@ paths:
     delete:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -313,11 +313,11 @@ paths:
     get:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -351,11 +351,11 @@ paths:
     patch:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -403,11 +403,11 @@ paths:
     patch:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -451,11 +451,11 @@ paths:
     get:
       description: ""
       parameters:
-      - name: "depth"
-        in: "query"
-        required: false
-        schema:
-          type: "string"
+        - name: "depth"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -506,11 +506,11 @@ paths:
     delete:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -543,16 +543,16 @@ paths:
     get:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      - name: "depth"
-        in: "query"
-        required: false
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: "depth"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -586,11 +586,11 @@ paths:
     patch:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -638,11 +638,11 @@ paths:
     patch:
       description: ""
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
       requestBody:
         content:
           application/json:
@@ -691,9 +691,6 @@ components:
           type: "string"
         name:
           type: "string"
-        price:
-          type: "number"
-          format: "float"
         description:
           type: "string"
         attributes:
@@ -705,11 +702,12 @@ components:
         updatedAt:
           type: "string"
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "spaceId"
-      - "createdAt"
+        - "id"
+        - "name"
+        - "description"
+        - "attributes"
+        - "spaceId"
+        - "createdAt"
     AddProductNetworkRequest:
       type: "object"
       properties:
@@ -720,9 +718,9 @@ components:
         spaceId:
           type: "string"
       required:
-      - "name"
-      - "description"
-      - "spaceId"
+        - "name"
+        - "description"
+        - "spaceId"
     ApiError:
       type: "object"
       properties:
@@ -733,8 +731,8 @@ components:
         context:
           type: "string"
       required:
-      - "type"
-      - "message"
+        - "type"
+        - "message"
     Error:
       type: "object"
       properties:
@@ -743,14 +741,14 @@ components:
           items:
             $ref: "#/components/schemas/ApiError"
       required:
-      - "errors"
+        - "errors"
     MoveProductNetworkRequest:
       type: "object"
       properties:
         targetSpaceId:
           type: "string"
       required:
-      - "targetSpaceId"
+        - "targetSpaceId"
     UpdateProductNetworkRequest:
       type: "object"
       properties:
@@ -781,11 +779,11 @@ components:
         updatedAt:
           type: "string"
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "storageId"
-      - "createdAt"
+        - "id"
+        - "name"
+        - "description"
+        - "storageId"
+        - "createdAt"
     AddSpaceNetworkRequest:
       type: "object"
       properties:
@@ -799,16 +797,16 @@ components:
         storageId:
           type: "string"
       required:
-      - "name"
-      - "description"
-      - "storageId"
+        - "name"
+        - "description"
+        - "storageId"
     MoveSpaceNetworkRequest:
       type: "object"
       properties:
         targetStorageId:
           type: "string"
       required:
-      - "targetStorageId"
+        - "targetStorageId"
     UpdateSpaceNetworkRequest:
       type: "object"
       properties:
@@ -841,12 +839,12 @@ components:
         updatedAt:
           type: "string"
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "spaces"
-      - "subStorages"
-      - "createdAt"
+        - "id"
+        - "name"
+        - "description"
+        - "spaces"
+        - "subStorages"
+        - "createdAt"
     AddStorageNetworkRequest:
       type: "object"
       properties:
@@ -857,8 +855,8 @@ components:
         parentId:
           type: "string"
       required:
-      - "name"
-      - "description"
+        - "name"
+        - "description"
     MoveStorageRequest:
       type: "object"
       properties:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -130,6 +130,58 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkProduct"
+  /v1/products/{id}/copy:
+    post:
+      description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopyProductRequest"
+        required: true
+      responses:
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+        "201":
+          description: "Created"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NetworkProduct"
   /v1/products/moveProduct/{id}/{spaceId}:
     patch:
       description: ""
@@ -685,6 +737,13 @@ components:
             $ref: "#/components/schemas/ApiError"
       required:
       - "errors"
+    CopyProductRequest:
+      type: "object"
+      properties:
+        targetSpaceId:
+          type: "string"
+      required:
+      - "targetSpaceId"
     NetworkSpace:
       type: "object"
       properties:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -294,6 +294,58 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkSpace"
+  /v1/spaces/{id}/copy:
+    post:
+      description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopySpaceRequest"
+        required: true
+      responses:
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+        "201":
+          description: "Created"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NetworkSpace"
   /v1/spaces/{id}/move:
     post:
       description: ""
@@ -672,6 +724,13 @@ components:
       - "name"
       - "description"
       - "storageId"
+    CopySpaceRequest:
+      type: "object"
+      properties:
+        targetStorageId:
+          type: "string"
+      required:
+      - "targetStorageId"
     MoveSpaceRequest:
       type: "object"
       properties:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -59,11 +59,11 @@ paths:
     delete:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -96,11 +96,11 @@ paths:
     get:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -130,15 +130,67 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkProduct"
+  /v1/products/{id}/copy:
+    post:
+      description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopyProductRequest"
+        required: true
+      responses:
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+        "201":
+          description: "Created"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NetworkProduct"
   /v1/products/{id}/move:
     patch:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -190,11 +242,11 @@ paths:
     patch:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -276,11 +328,11 @@ paths:
     delete:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -313,11 +365,11 @@ paths:
     get:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -347,15 +399,67 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkSpace"
+  /v1/spaces/{id}/copy:
+    post:
+      description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopySpaceRequest"
+        required: true
+      responses:
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+        "201":
+          description: "Created"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NetworkSpace"
   /v1/spaces/{id}/move:
     patch:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -403,11 +507,11 @@ paths:
     patch:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -451,11 +555,11 @@ paths:
     get:
       description: ""
       parameters:
-        - name: "depth"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
+      - name: "depth"
+        in: "query"
+        required: false
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -506,11 +610,11 @@ paths:
     delete:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -543,16 +647,16 @@ paths:
     get:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-        - name: "depth"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "depth"
+        in: "query"
+        required: false
+        schema:
+          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -582,15 +686,67 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkStorage"
+  /v1/storages/{id}/copy:
+    post:
+      description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopyStorageRequest"
+        required: true
+      responses:
+        "400":
+          description: "Bad Request"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
+                  description: ""
+                  value:
+                    errors: []
+        "201":
+          description: "Created"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NetworkStorage"
   /v1/storages/{id}/move:
     patch:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -638,11 +794,11 @@ paths:
     patch:
       description: ""
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -702,12 +858,12 @@ components:
         updatedAt:
           type: "string"
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "attributes"
-        - "spaceId"
-        - "createdAt"
+      - "id"
+      - "name"
+      - "description"
+      - "attributes"
+      - "spaceId"
+      - "createdAt"
     AddProductNetworkRequest:
       type: "object"
       properties:
@@ -718,9 +874,9 @@ components:
         spaceId:
           type: "string"
       required:
-        - "name"
-        - "description"
-        - "spaceId"
+      - "name"
+      - "description"
+      - "spaceId"
     ApiError:
       type: "object"
       properties:
@@ -731,8 +887,8 @@ components:
         context:
           type: "string"
       required:
-        - "type"
-        - "message"
+      - "type"
+      - "message"
     Error:
       type: "object"
       properties:
@@ -741,14 +897,21 @@ components:
           items:
             $ref: "#/components/schemas/ApiError"
       required:
-        - "errors"
+      - "errors"
+    CopyProductRequest:
+      type: "object"
+      properties:
+        targetSpaceId:
+          type: "string"
+      required:
+      - "targetSpaceId"
     MoveProductNetworkRequest:
       type: "object"
       properties:
         targetSpaceId:
           type: "string"
       required:
-        - "targetSpaceId"
+      - "targetSpaceId"
     UpdateProductNetworkRequest:
       type: "object"
       properties:
@@ -779,11 +942,11 @@ components:
         updatedAt:
           type: "string"
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "storageId"
-        - "createdAt"
+      - "id"
+      - "name"
+      - "description"
+      - "storageId"
+      - "createdAt"
     AddSpaceNetworkRequest:
       type: "object"
       properties:
@@ -797,16 +960,23 @@ components:
         storageId:
           type: "string"
       required:
-        - "name"
-        - "description"
-        - "storageId"
+      - "name"
+      - "description"
+      - "storageId"
+    CopySpaceRequest:
+      type: "object"
+      properties:
+        targetStorageId:
+          type: "string"
+      required:
+      - "targetStorageId"
     MoveSpaceNetworkRequest:
       type: "object"
       properties:
         targetStorageId:
           type: "string"
       required:
-        - "targetStorageId"
+      - "targetStorageId"
     UpdateSpaceNetworkRequest:
       type: "object"
       properties:
@@ -839,12 +1009,12 @@ components:
         updatedAt:
           type: "string"
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "spaces"
-        - "subStorages"
-        - "createdAt"
+      - "id"
+      - "name"
+      - "description"
+      - "spaces"
+      - "subStorages"
+      - "createdAt"
     AddStorageNetworkRequest:
       type: "object"
       properties:
@@ -855,8 +1025,13 @@ components:
         parentId:
           type: "string"
       required:
-        - "name"
-        - "description"
+      - "name"
+      - "description"
+    CopyStorageRequest:
+      type: "object"
+      properties:
+        newParentId:
+          type: "string"
     MoveStorageRequest:
       type: "object"
       properties:

--- a/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
@@ -13,14 +13,13 @@ import io.github.lagersystembackend.storage.StorageEntity
 import io.github.lagersystembackend.storage.StorageToStorages
 import io.github.lagersystembackend.storage.Storages
 import io.kotest.matchers.date.shouldBeBefore
-import io.kotest.matchers.equals.shouldBeEqual
+
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.*
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest

--- a/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
@@ -396,4 +396,17 @@ class PostgresProductRepositoryTest {
             this shouldBe  null
         }
     }
+    @Test
+    fun `copyProduct should correctly duplicate product structure`() {
+        val space = exampleSpace
+        val product = sut.createProduct("Original Product", "A product description", space.id)
+
+        val copiedProduct = sut.copyProduct(product.id, space.id)
+
+        copiedProduct.name shouldBe "${product.name} (Copy)"
+        copiedProduct.description shouldBe product.description
+        copiedProduct.spaceId shouldBe space.id
+        copiedProduct.attributes shouldBe product.attributes
+    }
+
 }

--- a/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
@@ -419,7 +419,7 @@ class PostgresProductRepositoryTest {
 
         val copiedProduct = sut.copyProduct(product.id, space.id)
 
-        copiedProduct.name shouldBe "${product.name} (Copy)"
+        copiedProduct.name shouldBe product.name
         copiedProduct.description shouldBe product.description
         copiedProduct.spaceId shouldBe space.id
         copiedProduct.attributes shouldBe product.attributes

--- a/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
@@ -22,6 +22,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.serialization.json.Json
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -433,7 +434,9 @@ class ProductRoutesKtTest {
             name = "Original Product",
             description = "A product description",
             attributes = emptyMap(),
-            spaceId = spaceId
+            spaceId = spaceId,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
         every { mockSpaceRepository.getSpace(spaceId) } returns Space(
             id = spaceId,
@@ -441,7 +444,9 @@ class ProductRoutesKtTest {
             size = 50f,
             description = "Space description",
             products = listOf(originalProduct),
-            storageId = UUID.randomUUID().toString()
+            storageId = UUID.randomUUID().toString(),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
         every { mockProductRepository.getProduct(productId) } returns originalProduct
         every { mockProductRepository.copyProduct(productId, spaceId) } answers {
@@ -500,7 +505,9 @@ class ProductRoutesKtTest {
             size = 50f,
             description = "Space description",
             products = emptyList(),
-            storageId = UUID.randomUUID().toString()
+            storageId = UUID.randomUUID().toString(),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
 
         client.post("/products/$productId/copy") {
@@ -550,7 +557,9 @@ class ProductRoutesKtTest {
             name = "Original Product",
             description = "A product description",
             attributes = emptyMap(),
-            spaceId = UUID.randomUUID().toString()
+            spaceId = UUID.randomUUID().toString(),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
 
         client.post("/products/$productId/copy") {

--- a/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
@@ -6,6 +6,7 @@ import io.github.lagersystembackend.attribute.Attribute
 import io.github.lagersystembackend.plugins.configureHTTP
 import io.github.lagersystembackend.plugins.configureSerialization
 import io.github.lagersystembackend.space.SpaceRepository
+import io.github.lagersystembackend.space.Space
 import io.kotest.matchers.shouldBe
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.*
@@ -285,6 +286,151 @@ class ProductRoutesKtTest {
             val expectedResponse = ApiResponse.Error(
                 listOf(ErrorMessages.PRODUCT_NOT_FOUND)
             )
+            Json.decodeFromString<ApiResponse.Error>(bodyAsText()) shouldBe expectedResponse
+        }
+    }
+
+    @Test
+    fun `copyProduct should duplicate product structure and return the copied product as NetworkProduct`() = testApplication {
+        createEnvironment()
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        val spaceId = UUID.randomUUID().toString()
+        val productId = UUID.randomUUID().toString()
+        val originalProduct = Product(
+            id = productId,
+            name = "Original Product",
+            description = "A product description",
+            attributes = emptyMap(),
+            spaceId = spaceId
+        )
+        every { mockSpaceRepository.getSpace(spaceId) } returns Space(
+            id = spaceId,
+            name = "Space",
+            size = 50f,
+            description = "Space description",
+            products = listOf(originalProduct),
+            storageId = UUID.randomUUID().toString()
+        )
+        every { mockProductRepository.getProduct(productId) } returns originalProduct
+        every { mockProductRepository.copyProduct(productId, spaceId) } answers {
+            originalProduct.copy(
+                id = UUID.randomUUID().toString(),
+                name = "${originalProduct.name} (Copy)"
+            )
+        }
+
+        val copyRequest = CopyProductRequest(targetSpaceId = spaceId)
+        val response = client.post("/products/$productId/copy") {
+            contentType(ContentType.Application.Json)
+            setBody(copyRequest)
+        }
+
+        response.status shouldBe HttpStatusCode.Created
+
+        val expectedCopiedProduct = mockProductRepository.copyProduct(productId, spaceId).toNetworkProduct()
+        val actualNetworkProduct = Json.decodeFromString<NetworkProduct>(response.bodyAsText())
+
+        expectedCopiedProduct.apply {
+            actualNetworkProduct.apply {
+                name shouldBe this@apply.name
+                description shouldBe this@apply.description
+                spaceId shouldBe this@apply.spaceId
+                attributes shouldBe this@apply.attributes
+            }
+        }
+    }
+
+    @Test
+    fun `copyProduct should return BadRequest if id is not a valid UUID`() = testApplication {
+        createEnvironment()
+        client.post("/products/invalid-uuid/copy").apply {
+            status shouldBe HttpStatusCode.BadRequest
+            val expectedResponse = ApiResponse.Error(listOf(ErrorMessages.INVALID_UUID_PRODUCT))
+            Json.decodeFromString<ApiResponse.Error>(bodyAsText()) shouldBe expectedResponse
+        }
+    }
+
+    @Test
+    fun `copyProduct should return NotFound if product does not exist`() = testApplication {
+        createEnvironment()
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        val productId = UUID.randomUUID().toString()
+        val spaceId = UUID.randomUUID().toString()
+
+        every { mockProductRepository.getProduct(productId) } returns null
+        every { mockSpaceRepository.getSpace(spaceId) } returns Space(
+            id = spaceId,
+            name = "Space",
+            size = 50f,
+            description = "Space description",
+            products = emptyList(),
+            storageId = UUID.randomUUID().toString()
+        )
+
+        client.post("/products/$productId/copy") {
+            contentType(ContentType.Application.Json)
+            setBody(CopyProductRequest(targetSpaceId = spaceId))
+        }.apply {
+            status shouldBe HttpStatusCode.NotFound
+            val expectedResponse = ApiResponse.Error(listOf(ErrorMessages.PRODUCT_NOT_FOUND))
+            Json.decodeFromString<ApiResponse.Error>(bodyAsText()) shouldBe expectedResponse
+        }
+    }
+
+    @Test
+    fun `copyProduct should return BadRequest when target space ID is invalid`() = testApplication {
+        createEnvironment()
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        val productId = UUID.randomUUID().toString()
+
+        client.post("/products/$productId/copy") {
+            contentType(ContentType.Application.Json)
+            setBody(CopyProductRequest(targetSpaceId = "invalid-uuid"))
+        }.apply {
+            status shouldBe HttpStatusCode.BadRequest
+            val expectedResponse = ApiResponse.Error(listOf(ErrorMessages.INVALID_UUID_SPACE))
+            Json.decodeFromString<ApiResponse.Error>(bodyAsText()) shouldBe expectedResponse
+        }
+    }
+
+    @Test
+    fun `copyProduct should return BadRequest when target space does not exist`() = testApplication {
+        createEnvironment()
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        val productId = UUID.randomUUID().toString()
+        val invalidSpaceId = UUID.randomUUID().toString()
+
+        every { mockSpaceRepository.getSpace(invalidSpaceId) } returns null
+        every { mockProductRepository.getProduct(productId) } returns Product(
+            id = productId,
+            name = "Original Product",
+            description = "A product description",
+            attributes = emptyMap(),
+            spaceId = UUID.randomUUID().toString()
+        )
+
+        client.post("/products/$productId/copy") {
+            contentType(ContentType.Application.Json)
+            setBody(CopyProductRequest(targetSpaceId = invalidSpaceId))
+        }.apply {
+            status shouldBe HttpStatusCode.BadRequest
+            val expectedResponse = ApiResponse.Error(listOf(ErrorMessages.SPACE_NOT_FOUND))
             Json.decodeFromString<ApiResponse.Error>(bodyAsText()) shouldBe expectedResponse
         }
     }

--- a/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
@@ -452,7 +452,7 @@ class ProductRoutesKtTest {
         every { mockProductRepository.copyProduct(productId, spaceId) } answers {
             originalProduct.copy(
                 id = UUID.randomUUID().toString(),
-                name = "${originalProduct.name} (Copy)"
+                name = originalProduct.name
             )
         }
 

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -253,4 +253,47 @@ class PostgresSpaceRepositoryTest {
         val movedSpace = sut.moveSpace(createdSpace.id, targetStorageId.toString())
         movedSpace.products shouldBe createdProducts
     }
+    @Test
+    fun `copySpace should correctly duplicate space structure including products`() = testApplication {
+        val storage = exampleStorageEntity
+        val productRepository = PostgresProductRepository()
+        val space = insertSpace()
+        val product = productRepository.createProduct("Product", "Original Product", space.id)
+
+        val copiedSpace = sut.copySpace(space.id, exampleStorageId.toString())
+
+        copiedSpace.name shouldBe "${space.name} (Copy)"
+        copiedSpace.size shouldBe space.size
+        copiedSpace.description shouldBe space.description
+        copiedSpace.storageId shouldBe storage.id.toString()
+
+        copiedSpace.products.size shouldBe 1
+        val copiedProduct = copiedSpace.products.first()
+        copiedProduct.name shouldBe "${product.name} (Copy)"
+        copiedProduct.description shouldBe product.description
+        copiedProduct.spaceId shouldBe copiedSpace.id
+        copiedProduct.attributes shouldBe emptyMap()
+    }
+    @Test
+    fun `copySpace should throw IllegalArgumentException when original space not found`() = testApplication {
+        val invalidSpaceId = UUID.randomUUID().toString()
+
+        runCatching { sut.copySpace(invalidSpaceId, exampleStorageId.toString()) }.exceptionOrNull().run {
+            this shouldNotBe null
+            this!!::class shouldBe IllegalArgumentException::class
+            this.message shouldBe "Space with ID $invalidSpaceId not found"
+        }
+    }
+    @Test
+    fun `copySpace should throw IllegalArgumentException when target storage not found`() = testApplication {
+        val spaceRepository = PostgresSpaceRepository()
+        val space = spaceRepository.createSpace("Space", 50f, "Original Space", exampleStorageId.toString())
+        val invalidStorageId = UUID.randomUUID().toString()
+
+        runCatching { sut.copySpace(space.id, invalidStorageId) }.exceptionOrNull().run {
+            this shouldNotBe null
+            this!!::class shouldBe IllegalArgumentException::class
+            this.message shouldBe "Storage with ID $invalidStorageId not found"
+        }
+    }
 }

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -253,6 +253,7 @@ class PostgresSpaceRepositoryTest {
         val movedSpace = sut.moveSpace(createdSpace.id, targetStorageId.toString())
         movedSpace.products shouldBe createdProducts
     }
+
     @Test
     fun `copySpace should correctly duplicate space structure including products`() = testApplication {
         val storage = exampleStorageEntity
@@ -274,6 +275,7 @@ class PostgresSpaceRepositoryTest {
         copiedProduct.spaceId shouldBe copiedSpace.id
         copiedProduct.attributes shouldBe emptyMap()
     }
+
     @Test
     fun `copySpace should throw IllegalArgumentException when original space not found`() = testApplication {
         val invalidSpaceId = UUID.randomUUID().toString()

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -9,8 +9,9 @@ import io.github.lagersystembackend.storage.StorageEntity
 import io.github.lagersystembackend.storage.StorageToStorages
 import io.github.lagersystembackend.storage.Storages
 import io.kotest.matchers.date.shouldBeBefore
-import io.kotest.matchers.equals.shouldBeEqual
-import io.kotest.matchers.should
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
+import org.jetbrains.exposed.sql.javatime.datetime
+import java.time.format.DateTimeFormatter
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.testApplication

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -280,14 +280,14 @@ class PostgresSpaceRepositoryTest {
 
         val copiedSpace = sut.copySpace(space.id, exampleStorageId.toString())
 
-        copiedSpace.name shouldBe "${space.name} (Copy)"
+        copiedSpace.name shouldBe space.name
         copiedSpace.size shouldBe space.size
         copiedSpace.description shouldBe space.description
         copiedSpace.storageId shouldBe storage.id.toString()
 
         copiedSpace.products.size shouldBe 1
         val copiedProduct = copiedSpace.products.first()
-        copiedProduct.name shouldBe "${product.name} (Copy)"
+        copiedProduct.name shouldBe product.name
         copiedProduct.description shouldBe product.description
         copiedProduct.spaceId shouldBe copiedSpace.id
         copiedProduct.attributes shouldBe emptyMap()

--- a/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
@@ -463,9 +463,13 @@ class SpaceRoutesKtTest {
                     name = "Original Product",
                     description = "A product description",
                     attributes = emptyMap(),
-                    spaceId = spaceId
+                    spaceId = spaceId,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now(),
                 )
-            )
+            ),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
         val mockStorage = Storage(
             id = storageId,
@@ -473,7 +477,9 @@ class SpaceRoutesKtTest {
             description = "Target Storage Description",
             spaces = listOf(originalSpace),
             parentId = null,
-            subStorages = listOf()
+            subStorages = listOf(),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
         every { mockSpaceRepository.getSpace(spaceId) } returns originalSpace
         every { mockSpaceRepository.copySpace(spaceId, storageId) } answers {
@@ -581,7 +587,7 @@ class SpaceRoutesKtTest {
         val validId = UUID.randomUUID().toString()
         val nonExistentStorageId = UUID.randomUUID().toString()
 
-        val originalSpace = Space(validId, "Original Space", 100f, "Description", storageId = UUID.randomUUID().toString(), products = listOf())
+        val originalSpace = Space(validId, "Original Space", 100f, "Description", storageId = UUID.randomUUID().toString(), products = listOf(),createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),)
         every { mockSpaceRepository.getSpace(validId) } returns originalSpace
         every { mockStorageRepository.getStorage(nonExistentStorageId) } returns null
 

--- a/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
@@ -485,11 +485,11 @@ class SpaceRoutesKtTest {
         every { mockSpaceRepository.copySpace(spaceId, storageId) } answers {
             originalSpace.copy(
                 id = UUID.randomUUID().toString(),
-                name = "${originalSpace.name} (Copy)",
+                name = originalSpace.name,
                 products = originalSpace.products.map { product ->
                     product.copy(
                         id = UUID.randomUUID().toString(),
-                        name = "${product.name} (Copy)"
+                        name = product.name
                     )
                 }
             )

--- a/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
@@ -329,26 +329,26 @@ class PostgresStorageRepositoryTest {
 
         val copiedStorage = sut.copyStorage(rootStorage.id, null)
 
-        copiedStorage.name shouldBe "${rootStorage.name} (Copy)"
+        copiedStorage.name shouldBe rootStorage.name
         copiedStorage.description shouldBe rootStorage.description
         copiedStorage.parentId shouldBe null
         copiedStorage.subStorages.size shouldBe 1
 
         val copiedSubStorage = copiedStorage.subStorages.first()
-        copiedSubStorage.name shouldBe "${subStorage.name} (Copy)"
+        copiedSubStorage.name shouldBe subStorage.name
         copiedSubStorage.description shouldBe subStorage.description
         copiedSubStorage.parentId shouldBe copiedStorage.id
 
         copiedSubStorage.spaces.size shouldBe 1
         val copiedSpace = copiedSubStorage.spaces.first()
-        copiedSpace.name shouldBe "${space.name} (Copy)"
+        copiedSpace.name shouldBe space.name
         copiedSpace.size shouldBe space.size
         copiedSpace.description shouldBe space.description
         copiedSpace.storageId shouldBe copiedSubStorage.id
 
         copiedSpace.products.size shouldBe 1
         val copiedProduct = copiedSpace.products.first()
-        copiedProduct.name shouldBe "${product.name} (Copy)"
+        copiedProduct.name shouldBe product.name
         copiedProduct.description shouldBe product.description
         copiedProduct.spaceId shouldBe copiedSpace.id
         copiedProduct.attributes shouldBe emptyMap()

--- a/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
@@ -537,15 +537,23 @@ class StorageRoutesKtTest {
                                     "Product",
                                     "A product",
                                     attributes = emptyMap(),
-                                    spaceId = spaceId
+                                    spaceId = spaceId,
+                                    createdAt = LocalDateTime.now(),
+                                    updatedAt = LocalDateTime.now(),
                                 )
-                            )
+                            ),
+                            createdAt = LocalDateTime.now(),
+                            updatedAt = LocalDateTime.now(),
                         )
                     ),
                     parentId = rootStorageId,
-                    subStorages = listOf()
+                    subStorages = listOf(),
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now(),
                 )
-            )
+            ),
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
         )
         every { mockStorageRepository.getStorage(rootStorageId) } returns rootStorage
         every { mockStorageRepository.copyStorage(rootStorageId, null) } answers {
@@ -699,7 +707,7 @@ class StorageRoutesKtTest {
         val validId = UUID.randomUUID().toString()
         val nonExistentParentId = UUID.randomUUID().toString()
 
-        val originalStorage = Storage(validId, "Original Storage", "Description", spaces = listOf(), parentId = null, subStorages = listOf())
+        val originalStorage = Storage(validId, "Original Storage", "Description", spaces = listOf(), parentId = null, subStorages = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),)
         every { mockStorageRepository.getStorage(validId) } returns originalStorage
         every { mockStorageRepository.getStorage(nonExistentParentId) } returns null
 

--- a/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
@@ -559,19 +559,19 @@ class StorageRoutesKtTest {
         every { mockStorageRepository.copyStorage(rootStorageId, null) } answers {
             rootStorage.copy(
                 id = UUID.randomUUID().toString(),
-                name = "${rootStorage.name} (Copy)",
+                name = rootStorage.name,
                 subStorages = rootStorage.subStorages.map { subStorage ->
                     subStorage.copy(
                         id = UUID.randomUUID().toString(),
-                        name = "${subStorage.name} (Copy)",
+                        name = subStorage.name,
                         spaces = subStorage.spaces.map { space ->
                             space.copy(
                                 id = UUID.randomUUID().toString(),
-                                name = "${space.name} (Copy)",
+                                name = space.name,
                                 products = space.products.map { product ->
                                     product.copy(
                                         id = UUID.randomUUID().toString(),
-                                        name = "${product.name} (Copy)"
+                                        name = product.name
                                     )
                                 }
                             )


### PR DESCRIPTION
Dont merge just yet, still some things to be implemented.

I want a feedback if this is the way we want to implement the copy function.

So far only implemented copy for storage. 
CopyStorage(a,b) comes with two parameters, a is the id of the storage you want to copy, and b is an optional (nullable) parameter where you can specify the ID of a storage where you want to paste it. If b is null the copied storage becomes a root storage.

Naturally CopyStorage also copies all spaces/products. If I would now implement CopySpace for example I would just copy some of the code in CopyStorage, as the code is essentially the same.

I thought about doing a singular copy function that takes in a UUID and then checks what object that UUID is and then handles the copy function accordingly. But im unsure how to implement a common route for all repositories.

If someone has better ideas to handle this please feel free to comment.