### PR TITLE
Changed moveStorage and moveSpace to HTTP Patch and changed the routes

### DIFF
--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -13,7 +13,6 @@ class PostgresProductRepository : ProductRepository {
         spaceId: String
     ): Product = transaction {
         val space = SpaceEntity.findById(UUID.fromString(spaceId)) ?: return@transaction throw IllegalArgumentException("Space not found")
-        val createTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         ProductEntity.new {
             this.name = name
             this.description = description

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -48,9 +48,13 @@ data class AddProductNetworkRequest(
 
 @Serializable
 data class UpdateProductNetworkRequest(
-    val id: String,
     val name: String? = null,
     val description: String? = null,
+)
+
+@Serializable
+data class MoveProductNetworkRequest(
+    val targetSpaceId: String
 )
 
 

--- a/src/main/kotlin/io/github/lagersystembackend/product/ProductRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/ProductRoutes.kt
@@ -56,6 +56,77 @@ fun Route.productRoutes(productRepository: ProductRepository, spaceRepository: S
 
                 call.respond(deletedProduct.toNetworkProduct())
             }
+            route("/update") {
+                patch {
+                    val id = call.parameters["id"]!!
+                    val errors = mutableListOf<ApiError>()
+
+                    if (!id.isUUID()) {
+                        errors.add(ErrorMessages.INVALID_UUID_PRODUCT)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val updateProductNetworkRequest = runCatching { call.receive<UpdateProductNetworkRequest>() }.getOrNull()
+
+                    if (updateProductNetworkRequest == null) {
+                        errors.add(ErrorMessages.BODY_NOT_SERIALIZED_PRODUCT)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val updatedProduct = updateProductNetworkRequest.let {
+                        productRepository.updateProduct(id, it.name, it.description)
+                    }
+
+                    if (updatedProduct == null) {
+                        errors.add(ErrorMessages.PRODUCT_NOT_FOUND)
+                        return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
+                    }
+
+                    updatedProduct.let {
+                        call.respond(
+                            HttpStatusCode.OK,
+                            it.toNetworkProduct()
+                        )
+                    }
+                }
+            }
+            route("/move") {
+                patch {
+                    val id = call.parameters["id"]!!
+                    val errors = mutableListOf<ApiError>()
+
+                    if (!id.isUUID()) {
+                        errors.add(ErrorMessages.INVALID_UUID_PRODUCT)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val moveProductNetworkRequest = runCatching { call.receive<MoveProductNetworkRequest>() }.getOrNull()
+
+                    if (moveProductNetworkRequest == null) {
+                        errors.add(ErrorMessages.BODY_NOT_SERIALIZED_SPACE)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val spaceId = moveProductNetworkRequest.targetSpaceId
+
+                    if (!spaceId.isUUID()) {
+                        errors.add(ErrorMessages.INVALID_UUID_SPACE)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    if (!spaceRepository.spaceExists(spaceId)) {
+                        errors.add(ErrorMessages.SPACE_NOT_FOUND)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val movedProduct = productRepository.moveProduct(id, spaceId)
+                    if (movedProduct == null) {
+                        errors.add(ErrorMessages.PRODUCT_NOT_FOUND)
+                        return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
+                    }
+                    call.respond(movedProduct.toNetworkProduct())
+                }
+            }
         }
         post {
             val errors = mutableListOf<ApiError>()
@@ -86,71 +157,6 @@ fun Route.productRoutes(productRepository: ProductRepository, spaceRepository: S
                     HttpStatusCode.Created,
                     it.toNetworkProduct()
                 )
-            }
-        }
-        route("/update") {
-            patch {
-                val errors = mutableListOf<ApiError>()
-                val updateProductNetworkRequest = runCatching { call.receive<UpdateProductNetworkRequest>() }.getOrNull()
-
-                if (updateProductNetworkRequest == null) {
-                    errors.add(ErrorMessages.BODY_NOT_SERIALIZED_PRODUCT)
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                if (!updateProductNetworkRequest.id.isUUID()) {
-                    errors.add(ErrorMessages.INVALID_UUID_PRODUCT)
-                }
-
-                if (errors.isNotEmpty()) {
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                val updatedProduct = updateProductNetworkRequest.let {
-                    productRepository.updateProduct(it.id, it.name, it.description)
-                }
-
-                if (updatedProduct == null) {
-                    errors.add(ErrorMessages.PRODUCT_NOT_FOUND)
-                    return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
-                }
-
-                updatedProduct.let {
-                    call.respond(
-                        HttpStatusCode.OK,
-                        it.toNetworkProduct()
-                    )
-                }
-            }
-        }
-        route("/moveProduct/{id}/{spaceId}") {
-            patch {
-                val errors = mutableListOf<ApiError>()
-                val id = call.parameters["id"]!!
-
-                if (!id.isUUID()) {
-                    errors.add(ErrorMessages.INVALID_UUID_PRODUCT)
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                val spaceId = call.parameters["spaceId"]!!
-
-                if (!spaceId.isUUID()) {
-                    errors.add(ErrorMessages.INVALID_UUID_SPACE)
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                if (!spaceRepository.spaceExists(spaceId)) {
-                    errors.add(ErrorMessages.SPACE_NOT_FOUND)
-                    return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
-                }
-
-                val movedProduct = productRepository.moveProduct(id, spaceId)
-                if (movedProduct == null) {
-                    errors.add(ErrorMessages.PRODUCT_NOT_FOUND)
-                    return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
-                }
-                call.respond(movedProduct.toNetworkProduct())
             }
         }
     }

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -15,7 +15,6 @@ class PostgresSpaceRepository : SpaceRepository {
         storageId: String
     ): Space = transaction {
         val storage = StorageEntity.findById(UUID.fromString(storageId)) ?: throw IllegalArgumentException("Storage not found")
-        val createTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         SpaceEntity.new {
             this.name = name
             this.size = size

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -53,14 +53,13 @@ data class AddSpaceNetworkRequest(
 
 @Serializable
 data class UpdateSpaceNetworkRequest(
-    val id: String,
     val name: String? = null,
     val size: Float? = null,
     val description: String? = null
 )
 
 @Serializable
-data class MoveSpaceRequest(
+data class MoveSpaceNetworkRequest(
     val targetStorageId: String
 )
 

--- a/src/main/kotlin/io/github/lagersystembackend/space/SpaceRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/SpaceRoutes.kt
@@ -54,30 +54,61 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
 
                 call.respond(deletedSpace.toNetworkSpace())
             }
+            route("/update") {
+                patch {
+                    val id = call.parameters["id"]!!
+                    val errors = mutableListOf<ApiError>()
+
+                    if (!id.isUUID()) {
+                        errors.add(ErrorMessages.INVALID_UUID_SPACE)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val updateSpaceNetworkRequest = runCatching { call.receive<UpdateSpaceNetworkRequest>() }.getOrNull()
+
+                    if (updateSpaceNetworkRequest == null) {
+                        errors.add(ErrorMessages.BODY_NOT_SERIALIZED_SPACE)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    if (!spaceRepository.spaceExists(id)) {
+                        errors.add(ErrorMessages.SPACE_NOT_FOUND)
+                        return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
+                    }
+
+                    val updatedSpace = updateSpaceNetworkRequest.let {
+                        spaceRepository.updateSpace(id, it.name, it.size, it.description)
+                    }
+
+                    updatedSpace?.let {
+                        call.respond(it.toNetworkSpace())
+                    }
+                }
+            }
             route("/move") {
-                post {
+                patch {
                     val id = call.parameters["id"]!!
                     val errors = mutableListOf<ApiError>()
 
                     if (!id.isUUID()) {
                         errors.add(ErrorMessages.INVALID_UUID_SPACE.withContext("ID: $id"))
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
-                    val moveRequest = runCatching { call.receive<MoveSpaceRequest>() }.getOrNull()
+                    val moveSpaceNetworkRequest = runCatching { call.receive<MoveSpaceNetworkRequest>() }.getOrNull()
 
-                    if (moveRequest == null) {
+                    if (moveSpaceNetworkRequest == null) {
                         errors.add(ErrorMessages.BODY_NOT_SERIALIZED_SPACE)
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
                     val space = spaceRepository.getSpace(id)
                     if (space == null) {
                         errors.add(ErrorMessages.SPACE_NOT_FOUND.withContext("ID: $id"))
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
                     }
 
-                    val targetStorageId = moveRequest.targetStorageId
+                    val targetStorageId = moveSpaceNetworkRequest.targetStorageId
                     if (!targetStorageId.isUUID()) {
                         errors.add(ErrorMessages.INVALID_UUID_STORAGE.withContext("Target Storage ID: $targetStorageId"))
                     } else if (!storageRepository.storageExists(targetStorageId)) {
@@ -85,16 +116,15 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
                     }
 
                     if (errors.isNotEmpty()) {
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
-                    val movedSpace = spaceRepository.moveSpace(id, moveRequest.targetStorageId)
+                    val movedSpace = spaceRepository.moveSpace(id, moveSpaceNetworkRequest.targetStorageId)
 
                     call.respond(movedSpace.toNetworkSpace())
                 }
             }
         }
-
         post {
             val errors = mutableListOf<ApiError>()
             val addSpaceNetworkRequest = runCatching { call.receive<AddSpaceNetworkRequest>() }.getOrNull()
@@ -121,38 +151,6 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
 
             createdSpace?.let {
                 call.respond(HttpStatusCode.Created, it.toNetworkSpace())
-            }
-        }
-
-        route("/update") {
-            patch {
-                val errors = mutableListOf<ApiError>()
-                val updateSpaceNetworkRequest = runCatching { call.receive<UpdateSpaceNetworkRequest>() }.getOrNull()
-
-                if (updateSpaceNetworkRequest == null) {
-                    errors.add(ErrorMessages.BODY_NOT_SERIALIZED_SPACE)
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                if (!updateSpaceNetworkRequest.id.isUUID()) {
-                    errors.add(ErrorMessages.INVALID_UUID_SPACE)
-                }
-
-                if (updateSpaceNetworkRequest.id.isUUID() && !spaceRepository.spaceExists(updateSpaceNetworkRequest.id)) {
-                    errors.add(ErrorMessages.SPACE_NOT_FOUND)
-                }
-
-                if (errors.isNotEmpty()) {
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                val updatedSpace = updateSpaceNetworkRequest.let {
-                    spaceRepository.updateSpace(it.id, it.name, it.size, it.description)
-                }
-
-                updatedSpace?.let {
-                    call.respond(it.toNetworkSpace())
-                }
             }
         }
     }

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -14,7 +14,6 @@ class PostgresStorageRepository: StorageRepository {
         parentId: String?,
     ): Storage = transaction {
         val parent = parentId?.let { StorageEntity.findById(UUID.fromString(it)) }
-        val createTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         val newStorage = StorageEntity.new {
             this.name = name
             this.description = description

--- a/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/Storage.kt
@@ -49,7 +49,6 @@ data class AddStorageNetworkRequest(
 
 @Serializable
 data class UpdateStorageNetworkRequest(
-    val id: String,
     val name: String? = null,
     val description: String? = null
 )

--- a/src/main/kotlin/io/github/lagersystembackend/storage/StorageRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/StorageRoutes.kt
@@ -1,7 +1,6 @@
 package io.github.lagersystembackend.storage
 
 import io.github.lagersystembackend.common.*
-import io.github.lagersystembackend.space.spaceRoutes
 import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
@@ -76,78 +75,78 @@ fun Route.storageRoutes(storageRepository: StorageRepository) {
 
                 call.respond(deletedStorage.toNetworkStorage())
             }
-            route("/move") {
-                post {
+            route("/update") {
+                patch {
                     val id = call.parameters["id"]!!
                     val errors = mutableListOf<ApiError>()
 
+                    if (!id.isUUID()) {
+                        errors.add(ErrorMessages.INVALID_UUID_STORAGE)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val updateStorageNetworkRequest = runCatching { call.receive<UpdateStorageNetworkRequest>() }.getOrNull()
+
+                    if (updateStorageNetworkRequest == null) {
+                        errors.add(ErrorMessages.BODY_NOT_SERIALIZED_STORAGE)
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    if (!storageRepository.storageExists(id)) {
+                        errors.add(ErrorMessages.STORAGE_NOT_FOUND)
+                        return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
+                    }
+
+                    val updatedStorage = updateStorageNetworkRequest.let {
+                        storageRepository.updateStorage(id, it.name, it.description)
+                    }
+
+                    updatedStorage?.let {
+                        call.respond(it.toNetworkStorage())
+                    }
+                }
+            }
+            route("/move") {
+                patch {
+                    val id = call.parameters["id"]!!
+                    val errors = mutableListOf<ApiError>()
 
                     if (!id.isUUID()) {
                         errors.add(ErrorMessages.INVALID_UUID_STORAGE)
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
-                    val moveRequest = runCatching { call.receive<MoveStorageRequest>() }.getOrNull()
-                    if (moveRequest == null) {
+                    val moveStorageNetworkRequest = runCatching { call.receive<MoveStorageRequest>() }.getOrNull()
+
+                    if (moveStorageNetworkRequest == null) {
                         errors.add(ErrorMessages.BODY_NOT_SERIALIZED_STORAGE)
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
-                    val targetParentId = moveRequest.newParentId
+                    val targetParentId = moveStorageNetworkRequest.newParentId
+
                     if (targetParentId != null) {
                         if (!targetParentId.isUUID()) {
                             errors.add(ErrorMessages.INVALID_UUID_STORAGE)
                         } else {
-                            val targetStorage = storageRepository.getStorage(targetParentId)
-                            if (targetStorage == null) {
+                            if (!storageRepository.storageExists(targetParentId)) {
                                 errors.add(ErrorMessages.STORAGE_NOT_FOUND.withContext("ID: $targetParentId"))
                             }
                         }
                     }
 
                     if (errors.isNotEmpty()) {
-                        return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
                     val storage = storageRepository.getStorage(id)
                     if (storage == null) {
                         errors.add(ErrorMessages.STORAGE_NOT_FOUND)
-                        return@post call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
+                        return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
                     }
 
                     val movedStorage = storageRepository.moveStorage(id, targetParentId)
                     call.respond(movedStorage.toNetworkStorage())
-                }
-            }
-        }
-        route("/update") {
-            patch {
-                val errors = mutableListOf<ApiError>()
-                val updateStorageRequest = runCatching { call.receive<UpdateStorageNetworkRequest>() }.getOrNull()
-
-                if (updateStorageRequest == null) {
-                    errors.add(ErrorMessages.BODY_NOT_SERIALIZED_STORAGE)
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                if (!updateStorageRequest.id.isUUID()) {
-                    errors.add(ErrorMessages.INVALID_UUID_STORAGE)
-                }
-
-                if (updateStorageRequest.id.isUUID() && !storageRepository.storageExists(updateStorageRequest.id)) {
-                    errors.add(ErrorMessages.STORAGE_NOT_FOUND)
-                }
-
-                if (errors.isNotEmpty()) {
-                    return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
-                }
-
-                val updatedStorage = storageRepository.let {
-                    it.updateStorage(updateStorageRequest.id, updateStorageRequest.name, updateStorageRequest.description)
-                }
-
-                updatedStorage?.let {
-                    call.respond(it.toNetworkStorage())
                 }
             }
         }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -130,7 +130,7 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkProduct"
-  /v1/products/moveProduct/{id}/{spaceId}:
+  /v1/products/{id}/move:
     patch:
       description: ""
       parameters:
@@ -139,11 +139,12 @@ paths:
         required: true
         schema:
           type: "string"
-      - name: "spaceId"
-        in: "path"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveProductNetworkRequest"
         required: true
-        schema:
-          type: "string"
       responses:
         "400":
           description: "Bad Request"
@@ -160,6 +161,14 @@ paths:
                   description: ""
                   value:
                     errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
+                Example#4:
+                  description: ""
+                  value:
+                    errors: []
         "404":
           description: "Not Found"
           content:
@@ -171,19 +180,21 @@ paths:
                   description: ""
                   value:
                     errors: []
-                Example#2:
-                  description: ""
-                  value:
-                    errors: []
         "200":
           description: "OK"
           content:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkProduct"
-  /v1/products/update:
+  /v1/products/{id}/update:
     patch:
       description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -337,7 +348,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NetworkSpace"
   /v1/spaces/{id}/move:
-    post:
+    patch:
       description: ""
       parameters:
       - name: "id"
@@ -349,7 +360,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/MoveSpaceRequest"
+              $ref: "#/components/schemas/MoveSpaceNetworkRequest"
         required: true
       responses:
         "400":
@@ -371,7 +382,14 @@ paths:
                   description: ""
                   value:
                     errors: []
-                Example#4:
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
                   description: ""
                   value:
                     errors: []
@@ -381,9 +399,15 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkSpace"
-  /v1/spaces/update:
+  /v1/spaces/{id}/update:
     patch:
       description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -403,6 +427,17 @@ paths:
                   value:
                     errors: []
                 Example#2:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
                   description: ""
                   value:
                     errors: []
@@ -548,7 +583,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NetworkStorage"
   /v1/storages/{id}/move:
-    post:
+    patch:
       description: ""
       parameters:
       - name: "id"
@@ -599,9 +634,15 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NetworkStorage"
-  /v1/storages/update:
+  /v1/storages/{id}/update:
     patch:
       description: ""
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       requestBody:
         content:
           application/json:
@@ -621,6 +662,17 @@ paths:
                   value:
                     errors: []
                 Example#2:
+                  description: ""
+                  value:
+                    errors: []
+        "404":
+          description: "Not Found"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                Example#1:
                   description: ""
                   value:
                     errors: []
@@ -690,17 +742,20 @@ components:
             $ref: "#/components/schemas/ApiError"
       required:
       - "errors"
+    MoveProductNetworkRequest:
+      type: "object"
+      properties:
+        targetSpaceId:
+          type: "string"
+      required:
+      - "targetSpaceId"
     UpdateProductNetworkRequest:
       type: "object"
       properties:
-        id:
-          type: "string"
         name:
           type: "string"
         description:
           type: "string"
-      required:
-      - "id"
     NetworkSpace:
       type: "object"
       properties:
@@ -745,7 +800,7 @@ components:
       - "name"
       - "description"
       - "storageId"
-    MoveSpaceRequest:
+    MoveSpaceNetworkRequest:
       type: "object"
       properties:
         targetStorageId:
@@ -755,8 +810,6 @@ components:
     UpdateSpaceNetworkRequest:
       type: "object"
       properties:
-        id:
-          type: "string"
         name:
           type: "string"
         size:
@@ -764,8 +817,6 @@ components:
           format: "float"
         description:
           type: "string"
-      required:
-      - "id"
     NetworkStorage:
       type: "object"
       properties:
@@ -814,11 +865,7 @@ components:
     UpdateStorageNetworkRequest:
       type: "object"
       properties:
-        id:
-          type: "string"
         name:
           type: "string"
         description:
           type: "string"
-      required:
-      - "id"


### PR DESCRIPTION
Ich habe moveStorage und moveSpace zu HTTP Patch geändert und die Routes von move und update so angepasst, dass sie jetzt die folgende Form haben: products/{id}/move bzw. products/{id}/update. Genau das gleiche habe ich für Space und Storage gemacht, sodass es einheitlich ist.