### PR TITLE
Added size and unit to product and space

### DIFF
--- a/src/main/kotlin/io/github/lagersystembackend/common/ApiResponse.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/common/ApiResponse.kt
@@ -27,4 +27,9 @@ object ErrorMessages {
     val INVALID_DEPTH = ApiError("INVALID_DEPTH" , "The provided depth parameter is invalid.")
     val RECURSIVE_MOVE = ApiError("RECURSIVE_MOVE" , "Cannot move storage to itself.")
     val RECURSIVE_COPY = ApiError("RECURSIVE_COPY" , "Cannot copy storage to itself.")
+    val SIZE_NOT_FITTING = ApiError("PRODUCT_NOT_FITTING" , "The size of the product exceeds the size of the space.")
+    val UNIT_NOT_FITTING = ApiError("UNIT_NOT_FITTING", "The unit of the product differs from the unit of the space.")
+    val SIZE_TOO_SMALL = ApiError("SIZE_TOO_SMALL", "The new size of the space must be larger than the size of the stored products.")
+    val NEGATIVE_SIZE = ApiError("NEGATIVE_SIZE" , "The size must be positive.")
+    val WRONG_SPECIFICATION = ApiError("WRONG_SPECIFICATION", "Size and unit have to be either both null or both not null.")
 }

--- a/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/PostgresProductRepository.kt
@@ -11,12 +11,30 @@ class PostgresProductRepository : ProductRepository {
     override fun createProduct(
         name: String,
         description: String,
+        size: Double?,
+        unit: String?,
         spaceId: String
     ): Product = transaction {
         val space = SpaceEntity.findById(UUID.fromString(spaceId)) ?: return@transaction throw IllegalArgumentException("Space not found")
+        if (space.unit != unit) {
+            throw IllegalArgumentException("Unit of product and space must match")
+        }
+        if (size != null) {
+            val currentSize = space.currentSize
+            val totalSize = space.totalSize
+
+            if (currentSize != null && totalSize != null) {
+                if (currentSize + size > totalSize) {
+                    throw IllegalArgumentException("product does not fit inside the space anymore")
+                }
+            }
+            space.currentSize = space.currentSize?.plus(size)
+        }
         ProductEntity.new {
             this.name = name
             this.description = description
+            this.size = size
+            this.unit = unit
             this.space = space
         }.toProduct()
     }
@@ -32,9 +50,21 @@ class PostgresProductRepository : ProductRepository {
     override fun updateProduct(
         id: String,
         name: String?,
-        description: String?
+        description: String?,
+        size: Double?,
     ): Product? = transaction {
         ProductEntity.findByIdAndUpdate(UUID.fromString(id)) { product ->
+            val currentSize = product.space.currentSize
+            val totalSize = product.space.totalSize
+            val oldSize = product.size
+            if (currentSize != null && totalSize != null && size != null && oldSize != null) {
+                if (currentSize - oldSize + size <= totalSize) {
+                    size.let { product.size = it }
+                    product.space.currentSize = product.space.currentSize?.minus(oldSize)?.plus(size)
+                } else {
+                    throw IllegalArgumentException("Product does not fit inside the space anymore.")
+                }
+            }
             name?.let { product.name = it }
             description?.let { product.description = it }
             product.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
@@ -44,14 +74,29 @@ class PostgresProductRepository : ProductRepository {
     override fun moveProduct(id: String, spaceId: String): Product? = transaction {
         val targetSpace = SpaceEntity.findById(UUID.fromString(spaceId)) ?: throw IllegalArgumentException("target Space not found")
         ProductEntity.findByIdAndUpdate(UUID.fromString(id)) { product ->
+            val size = product.size
+            val totalSize = targetSpace.totalSize
+            val currentSize = targetSpace.currentSize
+            if (size != null && totalSize != null && currentSize != null) {
+                if (currentSize.plus(size) <= totalSize) {
+                    product.space.currentSize = product.space.currentSize?.minus(size)
+                    targetSpace.currentSize = currentSize.plus(size)
+                } else {
+                    throw IllegalArgumentException("Product does not fit inside the new space.")
+                }
+            }
             product.space = targetSpace
             product.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }?.toProduct()
-
     }
 
     override fun deleteProduct(id: String): Product? = transaction {
-        ProductEntity.findById(UUID.fromString(id)).also { it?.delete() }?.toProduct()
+        val product = ProductEntity.findById(UUID.fromString(id)).also { it?.delete() } //?.toProduct()
+        val size = product?.size
+        if (product != null && size != null) {
+            product.space.currentSize = product.space.currentSize?.minus(size)
+        }
+        product?.toProduct()
     }
 
     override fun copyProduct(productId: String, targetSpaceId: String): Product {

--- a/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/Product.kt
@@ -22,17 +22,30 @@ data class Product(
     val id: String,
     val name: String,
     val description: String,
+    val size: Double?,
+    val unit: String?,
     val attributes: Map<String, Attribute>,
     val spaceId: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime?
-)
+) {
+    init {
+        val allNull = (size == null && unit == null)
+        val allDefined = (size != null && unit != null)
+
+        require(allNull || allDefined) {
+            "Either all of currentSize, totalSize, and unit must be defined, or none of them."
+        }
+    }
+}
 
 @Serializable
 data class NetworkProduct(
     val id: String,
     val name: String,
     val description: String,
+    val size: Double?,
+    val unit: String?,
     val attributes: Map<String, Attribute>,
     val spaceId: String,
     val createdAt: String,
@@ -43,6 +56,8 @@ data class NetworkProduct(
 data class AddProductNetworkRequest(
     val name: String,
     val description: String,
+    val size: Double?,
+    val unit: String?,
     val spaceId: String
 )
 
@@ -50,6 +65,7 @@ data class AddProductNetworkRequest(
 data class UpdateProductNetworkRequest(
     val name: String? = null,
     val description: String? = null,
+    val size: Double?,
 )
 
 @Serializable
@@ -65,6 +81,8 @@ data class CopyProductRequest(
 object Products: UUIDTable() {
     val name = varchar("name", 255)
     val description = text("description")
+    val size = double("size").nullable()
+    val unit = varchar("unit", 255).nullable()
     val spaceId = reference("spaceId", Spaces)
     val createdAt = datetime("createdAt").defaultExpression(CurrentDateTime)
     val updatedAt = datetime("updatedAt").nullable()
@@ -75,6 +93,8 @@ class ProductEntity(id: EntityID<UUID>) : UUIDEntity(id) {
 
     var name by Products.name
     var description by Products.description
+    var size by Products.size
+    var unit by Products.unit
     val attributes by ProductAttributeEntity referrersOn ProductAttributes.productId
     var space by SpaceEntity referencedOn Products.spaceId
     var createdAt by Products.createdAt
@@ -85,6 +105,8 @@ fun ProductEntity.toProduct() = Product(
     id.value.toString(),
     name,
     description,
+    size,
+    unit,
     attributes.associate { it.key to it.toAttribute() },
     space.id.value.toString(),
     createdAt,
@@ -95,6 +117,8 @@ fun Product.toNetworkProduct() = NetworkProduct(
     id,
     name,
     description,
+    size,
+    unit,
     attributes,
     spaceId,
     createdAt.format(DateTimeFormatter.ISO_DATE_TIME),

--- a/src/main/kotlin/io/github/lagersystembackend/product/ProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/ProductRepository.kt
@@ -1,10 +1,10 @@
 package io.github.lagersystembackend.product
 
 interface ProductRepository {
-    fun createProduct(name: String, description: String, spaceId: String): Product
+    fun createProduct(name: String, description: String, size: Double?, unit: String?, spaceId: String): Product
     fun getProduct(id: String): Product?
     fun getProducts(): List<Product>
-    fun updateProduct(id: String, name: String?, description: String?): Product?
+    fun updateProduct(id: String, name: String?, description: String?, size: Double?): Product?
     fun deleteProduct(id: String): Product?
     fun moveProduct(id: String, spaceId: String): Product?
     fun copyProduct(productId: String, targetSpaceId: String): Product

--- a/src/main/kotlin/io/github/lagersystembackend/product/ProductRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/product/ProductRoutes.kt
@@ -113,16 +113,33 @@ fun Route.productRoutes(productRepository: ProductRepository, spaceRepository: S
                         return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
-                    val updatedProduct = updateProductNetworkRequest.let {
-                        productRepository.updateProduct(id, it.name, it.description)
-                    }
+                    val product = productRepository.getProduct(id)
 
-                    if (updatedProduct == null) {
+                    if (product == null) {
                         errors.add(ErrorMessages.PRODUCT_NOT_FOUND)
                         return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
+                    } else {
+                        if (product.size != null && updateProductNetworkRequest.size != null) {
+                            val newSize = updateProductNetworkRequest.size - product.size
+                            if (updateProductNetworkRequest.size <= 0) {
+                                errors.add(ErrorMessages.NEGATIVE_SIZE)
+                            }
+
+                            if (!spaceRepository.fitsInSpace(product.spaceId, newSize)) {
+                                errors.add(ErrorMessages.SIZE_NOT_FITTING)
+                            }
+                        }
                     }
 
-                    updatedProduct.let {
+                    if (errors.isNotEmpty()) {
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    val updatedProduct = updateProductNetworkRequest.let {
+                        productRepository.updateProduct(id, it.name, it.description, it.size)
+                    }
+
+                    updatedProduct?.let {
                         call.respond(
                             HttpStatusCode.OK,
                             it.toNetworkProduct()
@@ -159,6 +176,18 @@ fun Route.productRoutes(productRepository: ProductRepository, spaceRepository: S
                         return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
+                    val size = productRepository.getProduct(id)?.size
+                    val unit = productRepository.getProduct(id)?.unit
+
+                    if (size != null && unit != null) {
+                        if (!spaceRepository.fitsInSpace(spaceId, size)) {
+                            errors.add(ErrorMessages.SIZE_NOT_FITTING)
+                        }
+                        if (!spaceRepository.checkUnit(spaceId, unit)) {
+                            errors.add(ErrorMessages.UNIT_NOT_FITTING)
+                        }
+                    }
+
                     val movedProduct = productRepository.moveProduct(id, spaceId)
                     if (movedProduct == null) {
                         errors.add(ErrorMessages.PRODUCT_NOT_FOUND)
@@ -182,6 +211,27 @@ fun Route.productRoutes(productRepository: ProductRepository, spaceRepository: S
                 if (addProductNetworkRequest.spaceId.isUUID() && !spaceRepository.spaceExists(addProductNetworkRequest.spaceId)) {
                     errors.add(ErrorMessages.SPACE_NOT_FOUND)
                 }
+
+                if (addProductNetworkRequest.unit != null && addProductNetworkRequest.size == null ||
+                    addProductNetworkRequest.unit == null && addProductNetworkRequest.size != null) {
+                    errors.add(ErrorMessages.WRONG_SPECIFICATION)
+                }
+
+                if (addProductNetworkRequest.unit != null) {
+                    if (!spaceRepository.checkUnit(addProductNetworkRequest.spaceId, addProductNetworkRequest.unit)) {
+                        errors.add(ErrorMessages.UNIT_NOT_FITTING)
+                    }
+                }
+
+                if (addProductNetworkRequest.size != null) {
+                    if (addProductNetworkRequest.size <= 0) {
+                        errors.add(ErrorMessages.NEGATIVE_SIZE)
+                    }
+
+                    if (!spaceRepository.fitsInSpace(addProductNetworkRequest.spaceId, addProductNetworkRequest.size)) {
+                        errors.add(ErrorMessages.SIZE_NOT_FITTING)
+                    }
+                }
             }
 
             if (errors.isNotEmpty()) {
@@ -189,7 +239,7 @@ fun Route.productRoutes(productRepository: ProductRepository, spaceRepository: S
             }
 
             val createdProduct = addProductNetworkRequest?.let {
-                productRepository.createProduct(it.name, it.description, it.spaceId)
+                productRepository.createProduct(it.name, it.description, it.size, it.unit, it.spaceId)
             }
 
             createdProduct?.let {

--- a/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepository.kt
@@ -1,6 +1,5 @@
 package io.github.lagersystembackend.space
 
-import io.github.lagersystembackend.common.isUUID
 import io.github.lagersystembackend.storage.StorageEntity
 import io.github.lagersystembackend.product.ProductEntity
 import io.github.lagersystembackend.attribute.ProductAttributeEntity
@@ -12,14 +11,17 @@ import java.util.UUID
 class PostgresSpaceRepository : SpaceRepository {
     override fun createSpace(
         name: String,
-        size: Float?,
         description: String,
+        size: Double?,
+        unit: String?,
         storageId: String
     ): Space = transaction {
         val storage = StorageEntity.findById(UUID.fromString(storageId)) ?: throw IllegalArgumentException("Storage not found")
         SpaceEntity.new {
             this.name = name
-            this.size = size
+            this.totalSize = size
+            this.currentSize = if (size != null) 0.0 else null
+            this.unit = unit
             this.description = description
             this.storage = storage
         }.toSpace()
@@ -36,12 +38,19 @@ class PostgresSpaceRepository : SpaceRepository {
     override fun updateSpace(
         id: String,
         name: String?,
-        size: Float?,
         description: String?,
+        size: Double?,
     ): Space? = transaction {
         SpaceEntity.findByIdAndUpdate(UUID.fromString(id)) { space ->
+            val currentSize = space.currentSize
+            if (size != null && currentSize != null) {
+                if (size >= currentSize) {
+                    size.let { space.totalSize = it }
+                } else {
+                    throw IllegalArgumentException("New size can not be smaller than current size of space.")
+                }
+            }
             name?.let { space.name = it }
-            size?.let { space.size = it }
             description?.let { space.description = it }
             space.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }?.toSpace()
@@ -81,7 +90,8 @@ class PostgresSpaceRepository : SpaceRepository {
 
             val newSpaceEntity = SpaceEntity.new {
                 name = originalSpace.name
-                size = originalSpace.size
+                totalSize = originalSpace.totalSize
+                currentSize = originalSpace.currentSize
                 description = originalSpace.description
                 storage = targetStorage
             }
@@ -100,6 +110,27 @@ class PostgresSpaceRepository : SpaceRepository {
                 }
             }
             newSpaceEntity.toSpace()
+        }
+    }
+
+    override fun checkUnit(spaceId: String, unit: String): Boolean = transaction {
+        val space = SpaceEntity.findById(UUID.fromString(spaceId))
+        if (space != null) {
+            val spaceUnit = space.unit
+            spaceUnit == unit
+        } else {
+            false
+        }
+    }
+
+    override fun fitsInSpace(spaceId: String, size: Double): Boolean = transaction {
+        val space = SpaceEntity.findById(UUID.fromString(spaceId))
+        if (space != null) {
+            val totalSize = space.totalSize
+            val currentSize = space.currentSize
+            totalSize != null && currentSize != null && currentSize + size <= totalSize
+        } else {
+            false
         }
     }
 

--- a/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/Space.kt
@@ -23,19 +23,37 @@ import java.util.UUID
 data class Space(
     val id: String,
     val name: String,
-    val size: Float?,
+    val totalSize: Double?,
+    val currentSize: Double?,
+    val unit: String?,
     val description: String,
     val products: List<Product>,
     val storageId: String,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime?
-)
+) {
+    init {
+        val allNull = (currentSize == null && totalSize == null && unit == null)
+        val allDefined = (currentSize != null && totalSize != null && unit != null)
+
+        require(allNull || allDefined) {
+            "Either all of currentSize, totalSize, and unit must be defined, or none of them."
+        }
+        if (currentSize != null && totalSize != null) {
+            require(currentSize <= totalSize) {
+                "currentSize cannot exceed totalSize."
+            }
+        }
+    }
+}
 
 @Serializable
 data class NetworkSpace(
     val id: String,
     val name: String,
-    val size: Float?,
+    val totalSize: Double?,
+    val currentSize: Double?,
+    val unit: String?,
     val description: String,
     val products: List<NetworkProduct>?,
     val storageId: String,
@@ -46,7 +64,8 @@ data class NetworkSpace(
 @Serializable
 data class AddSpaceNetworkRequest(
     val name: String,
-    val size: Float?,
+    val totalSize: Double?,
+    val unit: String?,
     val description: String,
     val storageId: String
 )
@@ -54,7 +73,7 @@ data class AddSpaceNetworkRequest(
 @Serializable
 data class UpdateSpaceNetworkRequest(
     val name: String? = null,
-    val size: Float? = null,
+    val totalSize: Double? = null,
     val description: String? = null
 )
 
@@ -70,7 +89,9 @@ data class CopySpaceRequest(
 
 object Spaces: UUIDTable() {
     val name = varchar("name", 255)
-    val size = float("size").nullable()
+    val totalSize = double("totalSize").nullable()
+    val currentSize = double("currentSize").nullable()
+    val unit = varchar("unit", 255).nullable()
     val description = text("description")
     val storageId = reference("storageId", Storages)
     val createdAt = datetime("createdAt").defaultExpression(CurrentDateTime)
@@ -81,7 +102,9 @@ class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
     companion object : UUIDEntityClass<SpaceEntity>(Spaces)
 
     var name by Spaces.name
-    var size by Spaces.size
+    var totalSize by Spaces.totalSize
+    var currentSize by Spaces.currentSize
+    var unit by Spaces.unit
     var description by Spaces.description
     val products by ProductEntity referrersOn Products.spaceId
     var storage by StorageEntity referencedOn Spaces.storageId
@@ -97,7 +120,9 @@ class SpaceEntity(id: EntityID<UUID>) : UUIDEntity(id) {
 fun SpaceEntity.toSpace() = Space(
     id.value.toString(),
     name,
-    size,
+    totalSize,
+    currentSize,
+    unit,
     description,
     products.map { it.toProduct() },
     storage.id.value.toString(),
@@ -108,7 +133,9 @@ fun SpaceEntity.toSpace() = Space(
 fun Space.toNetworkSpace() = NetworkSpace(
     id,
     name,
-    size,
+    totalSize,
+    currentSize,
+    unit,
     description,
     products.map { it.toNetworkProduct() },
     storageId,

--- a/src/main/kotlin/io/github/lagersystembackend/space/SpaceRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/SpaceRepository.kt
@@ -1,12 +1,14 @@
 package io.github.lagersystembackend.space
 
 interface SpaceRepository {
-    fun createSpace(name: String, size: Float?, description: String, storageId: String): Space
+    fun createSpace(name: String, description: String, size: Double?, unit: String?, storageId: String): Space
     fun getSpace(id: String): Space?
     fun getSpaces(): List<Space>
-    fun updateSpace(id: String, name: String?, size: Float?, description: String?): Space?
+    fun updateSpace(id: String, name: String?, description: String?, size: Double?): Space?
     fun deleteSpace(id: String): Space?
     fun spaceExists(id: String): Boolean
     fun moveSpace(spaceId: String, targetStorageId: String): Space
     fun copySpace(spaceId: String, targetStorageId: String): Space
+    fun checkUnit(spaceId: String, unit: String): Boolean
+    fun fitsInSpace(spaceId: String, size: Double): Boolean
 }

--- a/src/main/kotlin/io/github/lagersystembackend/space/SpaceRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/space/SpaceRoutes.kt
@@ -76,8 +76,24 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
                         return@patch call.respond(HttpStatusCode.NotFound, ApiResponse.Error(errors))
                     }
 
+                    val currentSize = spaceRepository.getSpace(id)?.currentSize
+                    val totalSize = updateSpaceNetworkRequest.totalSize
+
+                    if (currentSize != null && totalSize != null) {
+                        if (totalSize <= currentSize) {
+                            errors.add(ErrorMessages.SIZE_TOO_SMALL)
+                        }
+                        if (totalSize <= 0) {
+                            errors.add(ErrorMessages.NEGATIVE_SIZE)
+                        }
+                    }
+
+                    if (errors.isNotEmpty()) {
+                        return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
                     val updatedSpace = updateSpaceNetworkRequest.let {
-                        spaceRepository.updateSpace(id, it.name, it.size, it.description)
+                        spaceRepository.updateSpace(id, it.name, it.description, it.totalSize)
                     }
 
                     updatedSpace?.let {
@@ -180,6 +196,15 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
                 if (addSpaceNetworkRequest.storageId.isUUID() && !storageRepository.storageExists(addSpaceNetworkRequest.storageId)) {
                     errors.add(ErrorMessages.STORAGE_NOT_FOUND)
                 }
+
+                if (addSpaceNetworkRequest.unit != null && addSpaceNetworkRequest.totalSize == null ||
+                    addSpaceNetworkRequest.unit == null && addSpaceNetworkRequest.totalSize != null) {
+                    errors.add(ErrorMessages.WRONG_SPECIFICATION)
+                }
+
+                if (addSpaceNetworkRequest.totalSize != null && addSpaceNetworkRequest.totalSize <= 0) {
+                    errors.add(ErrorMessages.NEGATIVE_SIZE)
+                }
             }
 
             if (errors.isNotEmpty()) {
@@ -187,7 +212,7 @@ fun Route.spaceRoutes(spaceRepository: SpaceRepository, storageRepository: Stora
             }
 
             val createdSpace = addSpaceNetworkRequest?.let {
-                spaceRepository.createSpace(it.name, it.size, it.description, it.storageId)
+                spaceRepository.createSpace(it.name, it.description, it.totalSize, it.unit, it.storageId)
             }
 
             createdSpace?.let {

--- a/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepository.kt
@@ -88,7 +88,7 @@ class PostgresStorageRepository: StorageRepository {
     }
 
     override fun isCircularReference(storageId: String, targetParentId: String): Boolean = transaction {
-        val storage = StorageEntity.findById(UUID.fromString(storageId)) ?: return@transaction false
+        StorageEntity.findById(UUID.fromString(storageId)) ?: return@transaction false
         val targetParent = StorageEntity.findById(UUID.fromString(targetParentId)) ?: return@transaction false
         generateSequence(targetParent) { it.parent }.any { it.id.value.toString() == storageId }
     }
@@ -118,7 +118,9 @@ class PostgresStorageRepository: StorageRepository {
             originalStorage.spaces.forEach { space ->
                 val newSpaceEntity = SpaceEntity.new {
                     name = space.name 
-                    size = space.size
+                    totalSize = space.totalSize
+                    currentSize = space.currentSize
+                    unit = space.unit
                     description = space.description
                     storage = newStorageEntity
                 }
@@ -126,6 +128,8 @@ class PostgresStorageRepository: StorageRepository {
                     val newProductEntity = ProductEntity.new {
                         name = product.name 
                         description = product.description
+                        size = product.size
+                        unit = product.unit
                         this.space = newSpaceEntity
                     }
                     product.attributes.forEach { attribute ->

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -269,6 +269,10 @@ paths:
                   description: ""
                   value:
                     errors: []
+                Example#3:
+                  description: ""
+                  value:
+                    errors: []
         "404":
           description: "Not Found"
           content:
@@ -531,6 +535,10 @@ paths:
                   value:
                     errors: []
                 Example#2:
+                  description: ""
+                  value:
+                    errors: []
+                Example#3:
                   description: ""
                   value:
                     errors: []
@@ -849,6 +857,11 @@ components:
           type: "string"
         description:
           type: "string"
+        size:
+          type: "number"
+          format: "double"
+        unit:
+          type: "string"
         attributes:
           type: "string"
         spaceId:
@@ -870,6 +883,11 @@ components:
         name:
           type: "string"
         description:
+          type: "string"
+        size:
+          type: "number"
+          format: "double"
+        unit:
           type: "string"
         spaceId:
           type: "string"
@@ -919,6 +937,9 @@ components:
           type: "string"
         description:
           type: "string"
+        size:
+          type: "number"
+          format: "double"
     NetworkSpace:
       type: "object"
       properties:
@@ -926,9 +947,14 @@ components:
           type: "string"
         name:
           type: "string"
-        size:
+        totalSize:
           type: "number"
-          format: "float"
+          format: "double"
+        currentSize:
+          type: "number"
+          format: "double"
+        unit:
+          type: "string"
         description:
           type: "string"
         products:
@@ -952,9 +978,11 @@ components:
       properties:
         name:
           type: "string"
-        size:
+        totalSize:
           type: "number"
-          format: "float"
+          format: "double"
+        unit:
+          type: "string"
         description:
           type: "string"
         storageId:
@@ -982,9 +1010,9 @@ components:
       properties:
         name:
           type: "string"
-        size:
+        totalSize:
           type: "number"
-          format: "float"
+          format: "double"
         description:
           type: "string"
     NetworkStorage:

--- a/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/PostgresProductRepositoryTest.kt
@@ -63,6 +63,8 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
@@ -70,7 +72,7 @@ class PostgresProductRepositoryTest {
         )
 
 
-        expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }.apply {
+        expectedProduct.run { sut.createProduct(name, description, null, null, spaceId.toString()) }.apply {
             name shouldBe expectedProduct.name
             description shouldBe expectedProduct.description
             spaceId shouldBe expectedProduct.spaceId
@@ -86,13 +88,15 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             UUID.randomUUID().toString(),
             LocalDateTime.now(),
             LocalDateTime.now()
         )
         runCatching {
-            expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }
+            expectedProduct.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         }.exceptionOrNull().run {
             this shouldNotBe null
             this!!::class shouldBe IllegalArgumentException::class
@@ -106,13 +110,15 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             "Invalid UUID",
             LocalDateTime.now(),
             LocalDateTime.now()
         )
         runCatching {
-            expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }
+            expectedProduct.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         }.exceptionOrNull().run {
             this shouldNotBe null
             this!!::class shouldBe IllegalArgumentException::class
@@ -126,12 +132,14 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
             LocalDateTime.now()
         )
-        val createdProduct = expectedProduct.run { sut.createProduct(name, description, spaceId.toString()) }
+        val createdProduct = expectedProduct.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         sut.getProduct(createdProduct.id) shouldBe createdProduct
     }
 
@@ -159,6 +167,8 @@ class PostgresProductRepositoryTest {
                 "any id",
                 "name1",
                 "description",
+                null,
+                null,
                 emptyMap(),
                 spaceId.toString(),
                 LocalDateTime.now(),
@@ -168,6 +178,8 @@ class PostgresProductRepositoryTest {
                 "any id",
                 "name2",
                 "description",
+                null,
+                null,
                 mapOf(
                     "someKey" to Attribute.NumberAttribute(1.2f),
                     "someOtherKey" to Attribute.StringAttribute("some text"),
@@ -181,13 +193,15 @@ class PostgresProductRepositoryTest {
                 "any id",
                 "name3",
                 "description",
+                null,
+                null,
                 emptyMap(),
                 spaceId.toString(),
                 LocalDateTime.now(),
                 LocalDateTime.now()
             )
         )
-        expectedProducts = expectedProducts.map { it.run { sut.createProduct(name, description, spaceId) } }
+        expectedProducts = expectedProducts.map { it.run { sut.createProduct(name, description, null, null, spaceId) } }
         sut.getProducts() shouldBe expectedProducts
     }
 
@@ -202,18 +216,22 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
             LocalDateTime.now()
         )
-        val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
-        val updatedProduct = sut.updateProduct(createdProduct.id, "new name", "new description")
+        val createdProduct = product.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
+        val updatedProduct = sut.updateProduct(createdProduct.id, "new name", "new description", null)
 
         updatedProduct shouldBe Product(
             createdProduct.id,
             "new name",
             "new description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             createdProduct.createdAt,
@@ -229,13 +247,15 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
             LocalDateTime.now()
         )
-        val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
-        val updatedProduct = sut.updateProduct(createdProduct.id, null, null)
+        val createdProduct = product.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
+        val updatedProduct = sut.updateProduct(createdProduct.id, null, null, null)
 
         createdProduct.createdAt shouldBeBefore updatedProduct?.updatedAt!!
     }
@@ -243,7 +263,7 @@ class PostgresProductRepositoryTest {
     @Test
     fun `update Product should return null when Product not found`() = testApplication {
 
-        val updatedProduct = sut.updateProduct(UUID.randomUUID().toString(), "any new name", null)
+        val updatedProduct = sut.updateProduct(UUID.randomUUID().toString(), "any new name", null, null)
 
         updatedProduct shouldBe null
     }
@@ -252,7 +272,7 @@ class PostgresProductRepositoryTest {
     fun `update Product should throw IllegalArgumentException when id is invalid UUID`() = testApplication {
         val invalidUUID = "Invalid UUID"
         runCatching {
-            sut.updateProduct(invalidUUID, null, null)
+            sut.updateProduct(invalidUUID, null, null, null)
         }.exceptionOrNull().run {
             this shouldNotBe null
             this!!::class shouldBe IllegalArgumentException::class
@@ -265,12 +285,14 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
             LocalDateTime.now()
         )
-        val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
+        val createdProduct = product.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         sut.deleteProduct(createdProduct.id) shouldBe createdProduct
         sut.getProduct(createdProduct.id) shouldBe null
 
@@ -295,7 +317,7 @@ class PostgresProductRepositoryTest {
 
     @Test
     fun `delete Product should delete all of its attributes`() = testApplication {
-        val product = sut.createProduct("name", "description", spaceId.toString())
+        val product = sut.createProduct("name", "description", null, null, spaceId.toString())
         val productAttributeRepository = PostgresProductAttributeRepository()
         product.run {
             productAttributeRepository.createOrUpdateAttribute("someKey", Attribute.NumberAttribute(1.2f), id)
@@ -314,6 +336,8 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
@@ -329,13 +353,15 @@ class PostgresProductRepositoryTest {
             }.toSpace()
         }
 
-        val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
+        val createdProduct = product.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         val movedProduct = sut.moveProduct(createdProduct.id, secondSpaceId.toString())
 
         movedProduct shouldBe Product(
             createdProduct.id,
             createdProduct.name,
             createdProduct.description,
+            null,
+            null,
             emptyMap(),
             secondSpaceId.toString(),
             createdProduct.createdAt,
@@ -349,6 +375,8 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
@@ -364,7 +392,7 @@ class PostgresProductRepositoryTest {
             }.toSpace()
         }
 
-        val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
+        val createdProduct = product.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         val movedProduct = sut.moveProduct(createdProduct.id, secondSpaceId.toString())
 
         createdProduct.createdAt shouldBeBefore movedProduct?.updatedAt!!
@@ -389,12 +417,14 @@ class PostgresProductRepositoryTest {
             "any id",
             "name",
             "description",
+            null,
+            null,
             emptyMap(),
             spaceId.toString(),
             LocalDateTime.now(),
             LocalDateTime.now()
         )
-        val createdProduct = product.run { sut.createProduct(name, description, spaceId.toString()) }
+        val createdProduct = product.run { sut.createProduct(name, description, null, null, spaceId.toString()) }
         runCatching {
             sut.moveProduct(createdProduct.id, UUID.randomUUID().toString())
         }.exceptionOrNull().run {
@@ -415,7 +445,7 @@ class PostgresProductRepositoryTest {
     @Test
     fun `copyProduct should correctly duplicate product structure`() {
         val space = exampleSpace
-        val product = sut.createProduct("Original Product", "A product description", space.id)
+        val product = sut.createProduct("Original Product", "A product description", null, null, space.id)
 
         val copiedProduct = sut.copyProduct(product.id, space.id)
 

--- a/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/product/ProductRoutesKtTest.kt
@@ -22,7 +22,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.serialization.json.Json
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -47,8 +46,8 @@ class ProductRoutesKtTest {
     fun `get Products should respond with List of NetworkProducts`() = testApplication {
         createEnvironment()
         val products = listOf(
-            Product(UUID.randomUUID().toString(), "Space 1",  "Description 1",  emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now()),
-            Product(UUID.randomUUID().toString(), "Space 2", "Description 2", mapOf("someKey" to Attribute.NumberAttribute(123f)), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now())
+            Product(UUID.randomUUID().toString(), "Space 1",  "Description 1",  null, null, emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now()),
+            Product(UUID.randomUUID().toString(), "Space 2", "Description 2", null, null, mapOf("someKey" to Attribute.NumberAttribute(123f)), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now())
         )
         every { mockProductRepository.getProducts() } returns products
         client.get("/products").apply {
@@ -72,7 +71,7 @@ class ProductRoutesKtTest {
     fun `get Product by ID should respond with NetworkProduct`() = testApplication {
         createEnvironment()
         val product1 =
-            Product(UUID.randomUUID().toString(), "Space 1", "Description 1", emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now())
+            Product(UUID.randomUUID().toString(), "Space 1", "Description 1", null, null, emptyMap(), UUID.randomUUID().toString(), LocalDateTime.now(), LocalDateTime.now())
         every { mockProductRepository.getProduct(product1.id) } returns product1
         client.get("/products/${product1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -109,7 +108,7 @@ class ProductRoutesKtTest {
     @Test
     fun `delete Product should delete Product`() = testApplication {
         createEnvironment()
-        val product1 = Product(UUID.randomUUID().toString(), "Product 1", "Description 1", emptyMap(), "any id", LocalDateTime.now(), LocalDateTime.now())
+        val product1 = Product(UUID.randomUUID().toString(), "Product 1", "Description 1", null, null, emptyMap(), "any id", LocalDateTime.now(), LocalDateTime.now())
         every { mockProductRepository.deleteProduct(product1.id) } returns product1
         client.delete("/products/${product1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -156,10 +155,10 @@ class ProductRoutesKtTest {
         }
         val id = UUID.randomUUID().toString()
         val addProductNetworkRequest =
-            AddProductNetworkRequest("Product 1", "Description 1", UUID.randomUUID().toString())
+            AddProductNetworkRequest("Product 1", "Description 1", null, null, UUID.randomUUID().toString())
         addProductNetworkRequest.run {
-            val product = Product(id, name, description, emptyMap(), spaceId, createTime, createTime)
-            every { mockProductRepository.createProduct(name, description, spaceId) } returns product
+            val product = Product(id, name, description, null, null, emptyMap(), spaceId, createTime, createTime)
+            every { mockProductRepository.createProduct(name, description, null, null, spaceId) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
 
@@ -173,6 +172,8 @@ class ProductRoutesKtTest {
                     id,
                     addProductNetworkRequest.name,
                     addProductNetworkRequest.description,
+                    null,
+                    null,
                     emptyMap(),
                     addProductNetworkRequest.spaceId,
                     createTime,
@@ -194,10 +195,10 @@ class ProductRoutesKtTest {
         }
         val id = UUID.randomUUID().toString()
         val addProductNetworkRequest =
-            AddProductNetworkRequest("Space 1", "Description 1", UUID.randomUUID().toString())
+            AddProductNetworkRequest("Space 1", "Description 1", null, null, UUID.randomUUID().toString())
         addProductNetworkRequest.run {
-            val product = Product(id, name, description, emptyMap(), spaceId, createTime, createTime)
-            every { mockProductRepository.createProduct(name, description, spaceId) } returns product
+            val product = Product(id, name, description, null, null, emptyMap(), spaceId, createTime, createTime)
+            every { mockProductRepository.createProduct(name, description, null, null, spaceId) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
 
@@ -211,6 +212,8 @@ class ProductRoutesKtTest {
                     id,
                     addProductNetworkRequest.name,
                     addProductNetworkRequest.description,
+                    null,
+                    null,
                     emptyMap(),
                     addProductNetworkRequest.spaceId,
                     createTime,
@@ -253,11 +256,12 @@ class ProductRoutesKtTest {
         }
         val id = UUID.randomUUID().toString()
         val spaceId = UUID.randomUUID().toString()
-        val updateProductNetworkRequest = UpdateProductNetworkRequest("Product 1", "Description 1")
+        val updateProductNetworkRequest = UpdateProductNetworkRequest("Product 1", "Description 1", null)
         val createTime = LocalDateTime.now()
         updateProductNetworkRequest.run {
-            val product = Product(id, name!!, description!!, emptyMap(), spaceId, createTime, createTime)
-            every { mockProductRepository.updateProduct(id, name, description) } returns product
+            val product = Product(id, name!!, description!!, null, null, emptyMap(), spaceId, createTime, createTime)
+            every { mockProductRepository.updateProduct(id, name, description, null) } returns product
+            every { mockProductRepository.getProduct(id) } returns product
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
 
@@ -270,6 +274,8 @@ class ProductRoutesKtTest {
                 id,
                 updateProductNetworkRequest.name!!,
                 updateProductNetworkRequest.description!!,
+                null,
+                null,
                 emptyMap(),
                 spaceId,
                 createTime,
@@ -311,7 +317,7 @@ class ProductRoutesKtTest {
         }
         val invalidId = "invalid-id"
         val spaceId = UUID.randomUUID().toString()
-        val updateProductNetworkRequest = UpdateProductNetworkRequest("Product 1", "Description 1")
+        val updateProductNetworkRequest = UpdateProductNetworkRequest("Product 1", "Description 1", null)
         updateProductNetworkRequest.run {
             every { mockSpaceRepository.spaceExists(spaceId) } returns true
         }
@@ -406,6 +412,7 @@ class ProductRoutesKtTest {
         val spaceId = UUID.randomUUID().toString()
         val moveProductNetworkRequest = MoveProductNetworkRequest(spaceId)
         every { mockSpaceRepository.spaceExists(spaceId) } returns true
+        every { mockProductRepository.getProduct(productId) } returns null
         every { mockProductRepository.moveProduct(productId, spaceId) } returns null
         client.patch("/products/$productId/move") {
             setBody(moveProductNetworkRequest)
@@ -433,6 +440,8 @@ class ProductRoutesKtTest {
             id = productId,
             name = "Original Product",
             description = "A product description",
+            null,
+            null,
             attributes = emptyMap(),
             spaceId = spaceId,
             createdAt = LocalDateTime.now(),
@@ -441,7 +450,9 @@ class ProductRoutesKtTest {
         every { mockSpaceRepository.getSpace(spaceId) } returns Space(
             id = spaceId,
             name = "Space",
-            size = 50f,
+            null,
+            null,
+            null,
             description = "Space description",
             products = listOf(originalProduct),
             storageId = UUID.randomUUID().toString(),
@@ -502,7 +513,9 @@ class ProductRoutesKtTest {
         every { mockSpaceRepository.getSpace(spaceId) } returns Space(
             id = spaceId,
             name = "Space",
-            size = 50f,
+            null,
+            null,
+            null,
             description = "Space description",
             products = emptyList(),
             storageId = UUID.randomUUID().toString(),
@@ -556,6 +569,8 @@ class ProductRoutesKtTest {
             id = productId,
             name = "Original Product",
             description = "A product description",
+            null,
+            null,
             attributes = emptyMap(),
             spaceId = UUID.randomUUID().toString(),
             createdAt = LocalDateTime.now(),

--- a/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/PostgresSpaceRepositoryTest.kt
@@ -9,9 +9,6 @@ import io.github.lagersystembackend.storage.StorageEntity
 import io.github.lagersystembackend.storage.StorageToStorages
 import io.github.lagersystembackend.storage.Storages
 import io.kotest.matchers.date.shouldBeBefore
-import org.jetbrains.exposed.sql.javatime.CurrentDateTime
-import org.jetbrains.exposed.sql.javatime.datetime
-import java.time.format.DateTimeFormatter
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.testApplication
@@ -36,7 +33,6 @@ class PostgresSpaceRepositoryTest {
         SpaceEntity.new {
             name = "Space"
             description = "Test space"
-            size = 100f
             storage = exampleStorageEntity
         }.toSpace()
     }
@@ -67,12 +63,14 @@ class PostgresSpaceRepositoryTest {
     @Test
     fun `create Space should return Space`() = testApplication {
         val expectedSpace =
-            Space("anyId", "Space", 100f,"Space description", emptyList(), exampleStorageId.toString(), LocalDateTime.now(), LocalDateTime.now())
-        val createdStorage = expectedSpace.run { sut.createSpace(name, size, description, storageId) }
+            Space("anyId", "Space", null, null, null,"Space description", emptyList(), exampleStorageId.toString(), LocalDateTime.now(), LocalDateTime.now())
+        val createdStorage = expectedSpace.run { sut.createSpace(name, description, totalSize, unit, storageId) }
 
         createdStorage.apply {
             name shouldBe expectedSpace.name
-            size shouldBe expectedSpace.size
+            totalSize shouldBe expectedSpace.totalSize
+            currentSize shouldBe expectedSpace.currentSize
+            unit shouldBe expectedSpace.unit
             description shouldBe expectedSpace.description
             storageId shouldBe expectedSpace.storageId
             createdAt shouldBeBefore LocalDateTime.now()
@@ -83,7 +81,7 @@ class PostgresSpaceRepositoryTest {
     @Test
     fun `create Space should throw IllegalArgumentException when storageUUID is invalid UUID`() = testApplication {
         val invalidUUID = "invalidUUID"
-        runCatching { sut.createSpace("space", 100f, "description", invalidUUID) }
+        runCatching { sut.createSpace("space","description", null, null, invalidUUID) }
             .exceptionOrNull().run {
                 this shouldNotBe null
                 this!!::class shouldBe IllegalArgumentException::class
@@ -117,11 +115,11 @@ class PostgresSpaceRepositoryTest {
     fun `get Spaces should return List of Spaces`() = testApplication {
         val createTime = LocalDateTime.now()
         val expectedSpaces = listOf(
-            Space("anyId", "Space1", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime, createTime),
-            Space("anyId", "Space2", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime, createTime),
-            Space("anyId", "Space3", 100f,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime, createTime),
+            Space("anyId", "Space1", null, null, null,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime, createTime),
+            Space("anyId", "Space2", null, null, null,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime, createTime),
+            Space("anyId", "Space3", null, null, null,"Space description", products = emptyList(), storageId = exampleStorageId.toString(), createTime, createTime),
         )
-        val createdSpaces = expectedSpaces.map { it.run { sut.createSpace(name, size, description, storageId) } }
+        val createdSpaces = expectedSpaces.map { it.run { sut.createSpace(name, description, totalSize, unit, storageId) } }
         sut.getSpaces() shouldBe createdSpaces
     }
 
@@ -150,7 +148,7 @@ class PostgresSpaceRepositoryTest {
     @Test
     fun `update Space should update description`() = testApplication {
         val createdSpace = insertSpace()
-        sut.updateSpace(createdSpace.id, null, null, description = "newDescription")
+        sut.updateSpace(createdSpace.id, null, description = "newDescription", null)
         sut.getSpace(createdSpace.id)!!.apply {
             name shouldBe createdSpace.name
             description shouldBe "newDescription"
@@ -181,12 +179,12 @@ class PostgresSpaceRepositoryTest {
     fun `delete Space should delete products`() = testApplication {
         val createdSpace = insertSpace()
         val products = listOf(
-            Product("anyId", "Product1", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
-            Product("anyId", "Product2", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
-            Product("anyId", "Product3", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now())
+            Product("anyId", "Product1", "Space description", null, null, emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
+            Product("anyId", "Product2", "Space description", null, null, emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
+            Product("anyId", "Product3", "Space description", null, null, emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now())
         )
         val productRepository = PostgresProductRepository()
-        val createdProducts = products.map { it.run { productRepository.createProduct(name, description, spaceId) } }
+        val createdProducts = products.map { it.run { productRepository.createProduct(name, description, null, null, spaceId) } }
 
         sut.getSpace(createdSpace.id)!!.products shouldBe createdProducts
         sut.deleteSpace(createdSpace.id)
@@ -252,19 +250,21 @@ class PostgresSpaceRepositoryTest {
 
         movedSpace.name shouldBe createdSpace.name
         movedSpace.description shouldBe createdSpace.description
-        movedSpace.size shouldBe createdSpace.size
+        movedSpace.totalSize shouldBe createdSpace.totalSize
+        movedSpace.currentSize shouldBe createdSpace.totalSize
+        movedSpace.unit shouldBe createdSpace.unit
     }
 
     @Test
     fun `moveSpace should keep products after move`() = testApplication {
         val createdSpace = insertSpace()
         val products = listOf(
-            Product("anyId", "Product1", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
-            Product("anyId", "Product2", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
-            Product("anyId", "Product3", "Space description", emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now())
+            Product("anyId", "Product1", "Space description", null, null, emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
+            Product("anyId", "Product2", "Space description", null, null, emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now()),
+            Product("anyId", "Product3", "Space description", null, null, emptyMap(), createdSpace.id, LocalDateTime.now(), LocalDateTime.now())
         )
         val productRepository = PostgresProductRepository()
-        val createdProducts = products.map { it.run { productRepository.createProduct(name, description, createdSpace.id) } }
+        val createdProducts = products.map { it.run { productRepository.createProduct(name, description, null, null, createdSpace.id) } }
 
         sut.getSpace(createdSpace.id)!!.products shouldBe createdProducts
         val movedSpace = sut.moveSpace(createdSpace.id, targetStorageId.toString())
@@ -276,12 +276,14 @@ class PostgresSpaceRepositoryTest {
         val storage = exampleStorageEntity
         val productRepository = PostgresProductRepository()
         val space = insertSpace()
-        val product = productRepository.createProduct("Product", "Original Product", space.id)
+        val product = productRepository.createProduct("Product", "Original Product", null, null, space.id)
 
         val copiedSpace = sut.copySpace(space.id, exampleStorageId.toString())
 
         copiedSpace.name shouldBe space.name
-        copiedSpace.size shouldBe space.size
+        copiedSpace.totalSize shouldBe space.totalSize
+        copiedSpace.currentSize shouldBe space.currentSize
+        copiedSpace.unit shouldBe space.unit
         copiedSpace.description shouldBe space.description
         copiedSpace.storageId shouldBe storage.id.toString()
 
@@ -306,7 +308,7 @@ class PostgresSpaceRepositoryTest {
     @Test
     fun `copySpace should throw IllegalArgumentException when target storage not found`() = testApplication {
         val spaceRepository = PostgresSpaceRepository()
-        val space = spaceRepository.createSpace("Space", 50f, "Original Space", exampleStorageId.toString())
+        val space = spaceRepository.createSpace("Space", "Original Space", null, null, exampleStorageId.toString())
         val invalidStorageId = UUID.randomUUID().toString()
 
         runCatching { sut.copySpace(space.id, invalidStorageId) }.exceptionOrNull().run {

--- a/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/space/SpaceRoutesKtTest.kt
@@ -44,8 +44,8 @@ class SpaceRoutesKtTest {
     fun `get Spaces should respond with List of NetworkSpaces`() = testApplication {
         createEnvironment()
         val spaces = listOf(
-            Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
-            Space(UUID.randomUUID().toString(), "Space 2", 200f, "Description 2", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            Space(UUID.randomUUID().toString(), "Space 1",  null, null, null, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            Space(UUID.randomUUID().toString(), "Space 2", null, null, null, "Description 2", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         )
         every { mockSpaceRepository.getSpaces() } returns spaces
         client.get("/spaces").apply {
@@ -68,7 +68,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `get Space by ID should respond with NetworkSpace`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", null, null, null, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockSpaceRepository.getSpace(space1.id) } returns space1
         client.get("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -105,7 +105,7 @@ class SpaceRoutesKtTest {
     @Test
     fun `delete Space should delete Space`() = testApplication {
         createEnvironment()
-        val space1 = Space(UUID.randomUUID().toString(), "Space 1", 100f, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+        val space1 = Space(UUID.randomUUID().toString(), "Space 1", null, null, null, "Description 1", storageId = "any id", products = listOf(), createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
         every { mockSpaceRepository.deleteSpace(space1.id) } returns space1
         client.delete("/spaces/${space1.id}").apply {
             status shouldBe HttpStatusCode.OK
@@ -152,10 +152,10 @@ class SpaceRoutesKtTest {
 
         val id = UUID.randomUUID().toString()
         val storageId = UUID.randomUUID().toString()
-        val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", 100f, "Description 1", storageId = storageId)
+        val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", null, null, "Description 1", storageId = storageId)
         addSpaceNetworkRequest.run {
-            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now(), LocalDateTime.now())
-            every { mockSpaceRepository.createSpace(name, size, description, storageId) } returns space
+            val space = Space(id, name, null, null, null, description, products = listOf(), storageId, LocalDateTime.now(), LocalDateTime.now())
+            every { mockSpaceRepository.createSpace(name, description, null, null, storageId) } returns space
             every { mockStorageRepository.storageExists(storageId) } returns true
             client.post("/spaces") {
                 setBody(addSpaceNetworkRequest)
@@ -178,10 +178,10 @@ class SpaceRoutesKtTest {
 
         val id = UUID.randomUUID().toString()
         val storageId = UUID.randomUUID().toString()
-        val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", null, "Description 1", storageId = storageId)
+        val addSpaceNetworkRequest = AddSpaceNetworkRequest("Space 1", null, null, "Description 1", storageId = storageId)
         addSpaceNetworkRequest.run {
-            val space = Space(id, name, size, description, products = listOf(), storageId, LocalDateTime.now(), LocalDateTime.now())
-            every { mockSpaceRepository.createSpace(name, size, description, storageId) } returns space
+            val space = Space(id, name, null, null, null, description, products = listOf(), storageId, LocalDateTime.now(), LocalDateTime.now())
+            every { mockSpaceRepository.createSpace(name, description, null, null, storageId) } returns space
             every { mockStorageRepository.storageExists(storageId) } returns true
             client.post("/spaces") {
                 setBody(addSpaceNetworkRequest)
@@ -225,12 +225,13 @@ class SpaceRoutesKtTest {
         }
 
         val id = UUID.randomUUID().toString()
-        val updateSpaceNetworkRequest = UpdateSpaceNetworkRequest("Space 1", 100f, "Description 1")
+        val updateSpaceNetworkRequest = UpdateSpaceNetworkRequest("Space 1", null, "Description 1")
         val createTime = LocalDateTime.now()
         updateSpaceNetworkRequest.run {
-            val space = Space(id, name!!, size!!, description!!, products = listOf(), storageId = "any id", createTime, createTime)
+            val space = Space(id, name!!, null, null, null, description!!, products = listOf(), storageId = "any id", createTime, createTime)
+            every { mockSpaceRepository.getSpace(id) } returns space
             every { mockSpaceRepository.spaceExists(id) } returns true
-            every { mockSpaceRepository.updateSpace(id, name, size, description) } returns space
+            every { mockSpaceRepository.updateSpace(id, name, description, null) } returns space
             client.patch("/spaces/${id}/update") {
                 setBody(updateSpaceNetworkRequest)
                 contentType(ContentType.Application.Json)
@@ -272,7 +273,7 @@ class SpaceRoutesKtTest {
             }
         }
         val invalidId = "not-a-uuid"
-        val updateSpaceNetworkRequest = UpdateSpaceNetworkRequest("Space 1", 100f, "Description 1")
+        val updateSpaceNetworkRequest = UpdateSpaceNetworkRequest("Space 1", null, "Description 1")
         every { mockSpaceRepository.spaceExists(invalidId) } returns false
         client.patch("/spaces/${invalidId}/update") {
             setBody(updateSpaceNetworkRequest)
@@ -296,7 +297,7 @@ class SpaceRoutesKtTest {
             }
         }
         val id = UUID.randomUUID().toString()
-        val updateSpaceNetworkRequest = UpdateSpaceNetworkRequest("Space 1", 100f, "Description 1")
+        val updateSpaceNetworkRequest = UpdateSpaceNetworkRequest("Space 1", null, "Description 1")
         every { mockSpaceRepository.spaceExists(id) } returns false
         client.patch("/spaces/${id}/update") {
             setBody(updateSpaceNetworkRequest)
@@ -454,7 +455,9 @@ class SpaceRoutesKtTest {
         val originalSpace = Space(
             id = spaceId,
             name = "Original Space",
-            size = 100f,
+            null,
+            null,
+            null,
             description = "A space description",
             storageId = storageId,
             products = listOf(
@@ -462,6 +465,8 @@ class SpaceRoutesKtTest {
                     id = productId,
                     name = "Original Product",
                     description = "A product description",
+                    null,
+                    null,
                     attributes = emptyMap(),
                     spaceId = spaceId,
                     createdAt = LocalDateTime.now(),
@@ -507,7 +512,9 @@ class SpaceRoutesKtTest {
         expectedCopiedSpace.apply {
             actualCopiedSpace.apply {
                 name shouldBe this@apply.name
-                size shouldBe this@apply.size
+                totalSize shouldBe this@apply.totalSize
+                currentSize shouldBe this@apply.currentSize
+                unit shouldBe this@apply.unit
                 description shouldBe this@apply.description
                 products?.size shouldBe this@apply.products?.size
                 products?.zip(this@apply.products ?: listOf())?.forEach { (expectedProduct, actualProduct) ->
@@ -587,7 +594,7 @@ class SpaceRoutesKtTest {
         val validId = UUID.randomUUID().toString()
         val nonExistentStorageId = UUID.randomUUID().toString()
 
-        val originalSpace = Space(validId, "Original Space", 100f, "Description", storageId = UUID.randomUUID().toString(), products = listOf(),createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),)
+        val originalSpace = Space(validId, "Original Space", null, null, null, "Description", storageId = UUID.randomUUID().toString(), products = listOf(),createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),)
         every { mockSpaceRepository.getSpace(validId) } returns originalSpace
         every { mockStorageRepository.getStorage(nonExistentStorageId) } returns null
 

--- a/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/PostgresStorageRepositoryTest.kt
@@ -3,14 +3,12 @@ package io.github.lagersystembackend.storage
 import io.github.lagersystembackend.attribute.ProductAttributes
 import io.github.lagersystembackend.plugins.configureDatabases
 import io.github.lagersystembackend.product.PostgresProductRepository
-import io.github.lagersystembackend.product.ProductRepository
 import io.github.lagersystembackend.product.Products
 import io.github.lagersystembackend.space.PostgresSpaceRepository
 import io.github.lagersystembackend.space.Space
 import io.github.lagersystembackend.space.Spaces
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.date.shouldBeBefore
-import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.server.testing.testApplication
@@ -177,12 +175,12 @@ class PostgresStorageRepositoryTest {
     fun `delete Storage should delete spaces`() = testApplication {
         val rootStorage = insertRootStorage()
         val spaces = listOf(
-            Space("anyId", "Space1", 100f, "Space description", emptyList(), rootStorage.id, LocalDateTime.now(), LocalDateTime.now()),
-            Space("anyId", "Space2", 200f, "Space description", emptyList(), rootStorage.id, LocalDateTime.now(), LocalDateTime.now()),
-            Space("anyId", "Space3", 300f, "Space description", emptyList(), rootStorage.id, LocalDateTime.now(), LocalDateTime.now())
+            Space("anyId", "Space1", null, null, null, "Space description", emptyList(), rootStorage.id, LocalDateTime.now(), LocalDateTime.now()),
+            Space("anyId", "Space2", null, null, null, "Space description", emptyList(), rootStorage.id, LocalDateTime.now(), LocalDateTime.now()),
+            Space("anyId", "Space3", null, null, null, "Space description", emptyList(), rootStorage.id, LocalDateTime.now(), LocalDateTime.now())
         )
         val spaceRepository = PostgresSpaceRepository()
-        val createdSpaces = spaces.map { it.run { spaceRepository.createSpace(name, size, description, storageId) } }
+        val createdSpaces = spaces.map { it.run { spaceRepository.createSpace(name, description, null, null, storageId) } }
 
         sut.getStorage(rootStorage.id)!!.spaces shouldBe createdSpaces
         sut.deleteStorage(rootStorage.id)
@@ -324,8 +322,8 @@ class PostgresStorageRepositoryTest {
         val subStorage = sut.createStorage("SubStorage", "A sub-storage", rootStorage.id)
         val spaceRepository = PostgresSpaceRepository()
         val productRepository = PostgresProductRepository()
-        val space = spaceRepository.createSpace("Space", 0.5f, "A space", subStorage.id)
-        val product = productRepository.createProduct("Product", "A product", space.id)
+        val space = spaceRepository.createSpace("Space", "A space", null, null, subStorage.id)
+        val product = productRepository.createProduct("Product", "A product", null, null, space.id)
 
         val copiedStorage = sut.copyStorage(rootStorage.id, null)
 
@@ -342,7 +340,9 @@ class PostgresStorageRepositoryTest {
         copiedSubStorage.spaces.size shouldBe 1
         val copiedSpace = copiedSubStorage.spaces.first()
         copiedSpace.name shouldBe space.name
-        copiedSpace.size shouldBe space.size
+        copiedSpace.totalSize shouldBe space.totalSize
+        copiedSpace.currentSize shouldBe space.currentSize
+        copiedSpace.unit shouldBe space.unit
         copiedSpace.description shouldBe space.description
         copiedSpace.storageId shouldBe copiedSubStorage.id
 

--- a/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
+++ b/src/test/kotlin/io/github/lagersystembackend/storage/StorageRoutesKtTest.kt
@@ -528,7 +528,9 @@ class StorageRoutesKtTest {
                         Space(
                             spaceId,
                             "Space",
-                            0.5f,
+                            null,
+                            null,
+                            null,
                             "A space",
                             storageId = subStorageId,
                             products = listOf(
@@ -536,6 +538,8 @@ class StorageRoutesKtTest {
                                     productId,
                                     "Product",
                                     "A product",
+                                    null,
+                                    null,
                                     attributes = emptyMap(),
                                     spaceId = spaceId,
                                     createdAt = LocalDateTime.now(),
@@ -594,25 +598,25 @@ class StorageRoutesKtTest {
 
         expectedCopiedStorage.apply {
             actualCopiedStorage.apply {
-                name shouldBe "${this.name}"
+                name shouldBe this.name
                 description shouldBe this@apply.description
                 subStorages.size shouldBe this@apply.subStorages.size
                 subStorages.zip(this@apply.subStorages).forEach { (expectedSub, actualSub) ->
                     expectedSub.apply {
                         actualSub.apply {
-                            name shouldBe "${this.name}"
+                            name shouldBe this.name
                             description shouldBe this@apply.description
                             spaces.size shouldBe this@apply.spaces.size
                             spaces.zip(this@apply.spaces).forEach { (expectedSpace, actualSpace) ->
                                 expectedSpace.apply {
                                     actualSpace.apply {
-                                        name shouldBe "${this.name}"
+                                        name shouldBe this.name
                                         description shouldBe this@apply.description
                                         products?.size shouldBe this@apply.products?.size
                                         products?.zip(this@apply.products ?: listOf())?.forEach { (expectedProduct, actualProduct) ->
                                             expectedProduct.apply {
                                                 actualProduct.apply {
-                                                    name shouldBe "${this.name}"
+                                                    name shouldBe this.name
                                                     description shouldBe this@apply.description
                                                 }
                                             }


### PR DESCRIPTION
I have added size and unit to product and space. While the product only has a size and a unit, the space has a totalSize, a currentSize and a unit.
The currentSize indicates how much of the space is already filled by the products and the totalSize defines the size of the storage.
When adding a product to a space, the units must fit. Also the size of the product must not exceed the size of the space.

I chose to make size and unit nullable, so that we can still have abstract products in abstract spaces without any size information.
The only condition is that either size and unit are BOTH null or BOTH not null. There can not be a product without a unit but a size.
If you have a better solution to this, instead of making everything nullable, please let me know.