### PR TITLE
Changed post, copy and move route of StoredProduct

### DIFF
--- a/src/main/kotlin/io/github/lagersystembackend/stored_product/PostgresStoredProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/stored_product/PostgresStoredProductRepository.kt
@@ -50,7 +50,7 @@ class PostgresStoredProductRepository : StoredProductRepository {
     override fun updateStoredProduct(
         id: String,
         quantity: Int
-    ): StoredProduct = transaction {
+    ): StoredProductDTO = transaction {
         val storedProduct = StoredProductEntity.findById(UUID.fromString(id)) ?: throw IllegalArgumentException("Stored product not found")
 
         if (fitsInSpace(storedProduct.product.id.toString(), storedProduct.space.id.toString(), quantity - storedProduct.quantity)) {
@@ -58,7 +58,7 @@ class PostgresStoredProductRepository : StoredProductRepository {
             storedProduct.quantity = quantity
             storedProduct.updatedAt = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS)
         }
-        storedProduct.toStoredProduct()
+        storedProduct.toStoredProductDTO()
     }
 
     override fun moveStoredProduct(id: String, targetSpaceId: String): StoredProductDTO = transaction {
@@ -129,6 +129,12 @@ class PostgresStoredProductRepository : StoredProductRepository {
     override fun isStored(productId: String, spaceId: String): Boolean = transaction {
         StoredProductEntity.find {
             (StoredProducts.productId eq UUID.fromString(productId)) and (StoredProducts.spaceId eq UUID.fromString(spaceId)) }.count() > 0
+    }
+
+    override fun getId(productId: String, spaceId: String): String = transaction {
+        StoredProductEntity.find {
+            (StoredProducts.productId eq UUID.fromString(productId)) and (StoredProducts.spaceId eq UUID.fromString(spaceId))
+        }.firstOrNull()?.id?.value.toString()
     }
 
     override fun copyStoredProduct(id: String, targetSpaceId: String): StoredProductDTO = transaction {

--- a/src/main/kotlin/io/github/lagersystembackend/stored_product/StoredProductRepository.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/stored_product/StoredProductRepository.kt
@@ -8,7 +8,7 @@ interface StoredProductRepository {
     fun getStoredProduct(id: String): StoredProductDTO?
     fun getStoredProducts(): List<StoredProductDTO>
     fun getStoredProductsBySpaceId(spaceId: String): List<StoredProductDTO>
-    fun updateStoredProduct(id: String, quantity: Int): StoredProduct
+    fun updateStoredProduct(id: String, quantity: Int): StoredProductDTO
     fun moveStoredProduct(id: String, targetSpaceId: String): StoredProductDTO
     fun deleteStoredProduct(id: String): StoredProduct?
     fun spaceExists(id: String): Boolean
@@ -16,5 +16,6 @@ interface StoredProductRepository {
     fun fitsInSpace(productId: String, spaceId: String, quantity: Int): Boolean
     fun checkUnit(productId: String, spaceId: String): Boolean
     fun isStored(productId: String, spaceId: String): Boolean
+    fun getId(productId: String, spaceId: String): String
     fun copyStoredProduct(id: String, targetSpaceId: String): StoredProductDTO
 }

--- a/src/main/kotlin/io/github/lagersystembackend/stored_product/StoredProductRoutes.kt
+++ b/src/main/kotlin/io/github/lagersystembackend/stored_product/StoredProductRoutes.kt
@@ -94,7 +94,7 @@ fun Route.storedProductRoutes(storedProductRepository: StoredProductRepository, 
                         storedProductRepository.updateStoredProduct(id, it.quantity)
                     }
 
-                    call.respond(updatedStoredProduct.toNetworkStoredProduct())
+                    call.respond(updatedStoredProduct)
                 }
             }
             route("/move") {
@@ -139,6 +139,16 @@ fun Route.storedProductRoutes(storedProductRepository: StoredProductRepository, 
                     if (!storedProductRepository.checkUnit(storedProduct.productId, targetSpaceId)) {
                         errors.add(ErrorMessages.UNIT_NOT_FITTING)
                         return@patch call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                    }
+
+                    if (storedProductRepository.isStored(storedProduct.productId, targetSpaceId)) {
+                        val alreadyStoredProductId = storedProductRepository.getId(storedProduct.productId, targetSpaceId)
+                        val alreadyStoredProduct = storedProductRepository.getStoredProduct(alreadyStoredProductId)
+                        val updatedStoredProduct = alreadyStoredProduct?.let {
+                            storedProductRepository.updateStoredProduct(alreadyStoredProductId, alreadyStoredProduct.quantity + storedProduct.quantity)
+                        }
+                        storedProductRepository.deleteStoredProduct(id)
+                        updatedStoredProduct?.let {  return@patch call.respond(it)}
                     }
 
                     val movedStoredProduct = storedProductRepository.moveStoredProduct(id, moveStoredProductRequest.targetSpaceId)
@@ -193,6 +203,15 @@ fun Route.storedProductRoutes(storedProductRepository: StoredProductRepository, 
                         return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
                     }
 
+                    if (storedProductRepository.isStored(storedProduct.productId, targetSpaceId)) {
+                        val alreadyStoredProductId = storedProductRepository.getId(storedProduct.productId, targetSpaceId)
+                        val alreadyStoredProduct = storedProductRepository.getStoredProduct(alreadyStoredProductId)
+                        val updatedStoredProduct = alreadyStoredProduct?.let {
+                            storedProductRepository.updateStoredProduct(alreadyStoredProductId, alreadyStoredProduct.quantity + storedProduct.quantity)
+                        }
+                        updatedStoredProduct?.let {  return@post call.respond(it)}
+                    }
+
                     val copiedStoredProduct = storedProductRepository.copyStoredProduct(id, targetSpaceId)
                     call.respond(HttpStatusCode.Created, copiedStoredProduct)
                 }
@@ -224,6 +243,7 @@ fun Route.storedProductRoutes(storedProductRepository: StoredProductRepository, 
 
             if (storedProduct == null) {
                 errors.add(ErrorMessages.BODY_NOT_SERIALIZED_STORED_PRODUCT)
+                return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
             } else {
                 if (!storedProduct.productId.isUUID()) {
                     errors.add(ErrorMessages.INVALID_UUID_PRODUCT)
@@ -244,10 +264,6 @@ fun Route.storedProductRoutes(storedProductRepository: StoredProductRepository, 
                     errors.add(ErrorMessages.NEGATIVE_SIZE)
                 }
 
-                if (storedProductRepository.isStored(storedProduct.productId, storedProduct.spaceId)) {
-                    errors.add(ErrorMessages.ALREADY_STORED)
-                }
-
                 if (!storedProductRepository.fitsInSpace(storedProduct.productId, storedProduct.spaceId, storedProduct.quantity)) {
                     errors.add(ErrorMessages.SIZE_NOT_FITTING)
                 }
@@ -255,16 +271,26 @@ fun Route.storedProductRoutes(storedProductRepository: StoredProductRepository, 
                 if (!storedProductRepository.checkUnit(storedProduct.productId, storedProduct.spaceId)) {
                     errors.add(ErrorMessages.UNIT_NOT_FITTING)
                 }
-            }
-            if (errors.isNotEmpty()) {
-                return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+
+                if (errors.isNotEmpty()) {
+                    return@post call.respond(HttpStatusCode.BadRequest, ApiResponse.Error(errors))
+                }
+
+                if (storedProductRepository.isStored(storedProduct.productId, storedProduct.spaceId)) {
+                    val alreadyStoredProductId = storedProductRepository.getId(storedProduct.productId, storedProduct.spaceId)
+                    val alreadyStoredProduct = storedProductRepository.getStoredProduct(alreadyStoredProductId)
+                    val updatedStoredProduct = alreadyStoredProduct?.let {
+                        storedProductRepository.updateStoredProduct(alreadyStoredProduct.id, alreadyStoredProduct.quantity + storedProduct.quantity)
+                    }
+                    updatedStoredProduct?.let {  return@post call.respond(it)}
+                }
             }
 
-            val createdStoredProduct = storedProduct?.let {
+            val createdStoredProduct = storedProduct.let {
                 storedProductRepository.createStoredProduct(it.productId, it.spaceId, it.quantity)
             }
 
-            createdStoredProduct?.let {
+            createdStoredProduct.let {
                 call.respond(HttpStatusCode.Created, it)
             }
         }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -770,6 +770,16 @@ paths:
                   description: ""
                   value:
                     errors: []
+                Example#2:
+                  description: ""
+                  value:
+                    errors: []
+        "200":
+          description: "OK"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/StoredProductDTO"
         "201":
           description: "Created"
           content:
@@ -934,6 +944,12 @@ paths:
                   description: ""
                   value:
                     errors: []
+        "200":
+          description: "OK"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/StoredProductDTO"
         "201":
           description: "Created"
           content:
@@ -1051,7 +1067,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/NetworkStoredProduct"
+                $ref: "#/components/schemas/StoredProductDTO"
 components:
   schemas:
     NetworkProduct:


### PR DESCRIPTION
If the product is already stored inside a space and a create, move or copy occurs, only the quantity gets changed. The check if the product still fits inside the space is done before.